### PR TITLE
Enforce the use of && and || logical operators

### DIFF
--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -54,6 +54,8 @@
     <rule ref="Squiz.Functions.LowercaseFunctionKeywords"/>
     <rule ref="PSR2.Methods.MethodDeclaration"/>
 
+    <rule ref="Squiz.Operators.ValidLogicalOperators"/>
+
     <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
     <rule ref="Squiz.PHP.CommentedOutCode">
         <properties>

--- a/moodle/tests/fixtures/squiz_operators_validlogicaloperators.php
+++ b/moodle/tests/fixtures/squiz_operators_validlogicaloperators.php
@@ -1,0 +1,33 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+// All these are ok.
+if ($value === true || $other === true) {
+    yes();
+}
+
+if ($value === true && $other === true) {
+    yes();
+}
+
+if ($one === true && ($two === true || $three === true)) {
+    yes();
+}
+
+$a = 1 || 2 || 3 && 4 && 5;
+$a = $a ^ $b;
+$a = $a xor $b;
+
+// And these are wrong.
+if ($value === true or $other === true) {
+    yes();
+}
+
+if ($value === true and $other === true) {
+    yes();
+}
+
+if ($one === true AND ($two === true OR $three === true)) {
+    yes();
+}
+
+$a = 1 OR 2 or 3 AND 4 and 5;

--- a/moodle/tests/squiz_operators_validlogicaloperators_test.php
+++ b/moodle/tests/squiz_operators_validlogicaloperators_test.php
@@ -1,0 +1,58 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\tests;
+
+// phpcs:disable moodle.NamingConventions
+
+/**
+ * Test the PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\ValidLogicalOperatorsSniff sniff.
+ *
+ * @package    local_codechecker
+ * @category   test
+ * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\ValidLogicalOperatorsSniff
+ */
+class squiz_operators_validlogicaloperators_test extends local_codechecker_test {
+
+    /**
+     * Test the Squid.Arrays.ValidLogicalOperators sniff
+     */
+    public function test_squiz_operators_validlogicaloperators() {
+
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('Squiz.Operators.ValidLogicalOperators');
+        $this->set_fixture(__DIR__ . '/fixtures/squiz_operators_validlogicaloperators.php');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $this->set_errors([
+            21 => 'Logical operator "or" is prohibited; use "||" instead',
+            25 => 'Squiz.Operators.ValidLogicalOperators.NotAllowed',
+            29 => 2,
+            33 => 4,
+        ]);
+        $this->set_warnings([]);
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+}


### PR DESCRIPTION
This errors on any "and", "or" use, encouraging to, always,
use the "&&", "||" alternatives.

Agreed on July 2022 @ https://tracker.moodle.org/browse/MDL-74990

Covered with tests, we are using here existing sniff.