### PR TITLE
Lower the "and" and "or" uses down from error to warning

### DIFF
--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -54,7 +54,9 @@
     <rule ref="Squiz.Functions.LowercaseFunctionKeywords"/>
     <rule ref="PSR2.Methods.MethodDeclaration"/>
 
-    <rule ref="Squiz.Operators.ValidLogicalOperators"/>
+    <rule ref="Squiz.Operators.ValidLogicalOperators">
+        <type>warning</type>
+    </rule>
 
     <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
     <rule ref="Squiz.PHP.CommentedOutCode">


### PR DESCRIPTION
The correct outcome is to make them errors, but in order to give developers a little bit of time (1 year) we have agreed to lowerthem to be "just" warnings.

Them, in August 2023, by https://github.com/moodlehq/moodle-cs/issues/5 ,  we will raise the detection back to be error.

Note that this doesn't require the unit tests to be changed, they continue being reported as errors within PHPUnit. That's completely normal, because the tests don't read the `ruleset.xml` file but just load one Sniff and run it as is.

It's also possible to change that, but it only adds extra complications, to be reverted in 1 year.

You can verify that it works by running the real `phpcs` and will see those detections now being reported as warnings:

```
$ vendor/bin/phpcs --standard=moodle moodle/tests/fixtures/squiz_operators_validlogicaloperators.php 

FILE: /.../moodle-cs/moodle/tests/fixtures/squiz_operators_validlogicaloperators.php
------------------------------------------------------------------------------------------------------------------------------------
FOUND 14 ERRORS AND 8 WARNINGS AFFECTING 6 LINES
------------------------------------------------------------------------------------------------------------------------------------
  2 | ERROR   | Line 1 of the opening comment must start "// This file is part of".
  2 | ERROR   | Line 2 of the opening comment must start "//".
  2 | ERROR   | Line 3 of the opening comment must start "// Moodle is free software: you can redistribute it and/or modify".
  2 | ERROR   | Line 4 of the opening comment must start "// it under the terms of the GNU General Public License as published by".
  2 | ERROR   | Line 5 of the opening comment must start "// the Free Software Foundation, either version 3 of the License, or".
  2 | ERROR   | Line 6 of the opening comment must start "// (at your option) any later version.".
  2 | ERROR   | Line 7 of the opening comment must start "//".
  2 | ERROR   | Line 8 of the opening comment must start "// Moodle is distributed in the hope that it will be useful,".
  2 | ERROR   | Line 9 of the opening comment must start "// but WITHOUT ANY WARRANTY; without even the implied warranty of".
  2 | ERROR   | Line 10 of the opening comment must start "// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the".
  2 | ERROR   | Line 11 of the opening comment must start "// GNU General Public License for more details.".
  2 | ERROR   | Line 12 of the opening comment must start "//".
  2 | ERROR   | Line 13 of the opening comment must start "// You should have received a copy of the GNU General Public License".
  3 | ERROR   | Line 14 of the opening comment must start "// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.".
 21 | WARNING | Logical operator "or" is prohibited; use "||" instead
 25 | WARNING | Logical operator "and" is prohibited; use "&&" instead
 29 | WARNING | Logical operator "and" is prohibited; use "&&" instead
 29 | WARNING | Logical operator "or" is prohibited; use "||" instead
 33 | WARNING | Logical operator "or" is prohibited; use "||" instead
 33 | WARNING | Logical operator "or" is prohibited; use "||" instead
 33 | WARNING | Logical operator "and" is prohibited; use "&&" instead
 33 | WARNING | Logical operator "and" is prohibited; use "&&" instead
------------------------------------------------------------------------------------------------------------------------------------

Time: 88ms; Memory: 12MB
```