### PR TITLE
The use of class_alias is not a side effect

### DIFF
--- a/moodle/Sniffs/Files/MoodleInternalSniff.php
+++ b/moodle/Sniffs/Files/MoodleInternalSniff.php
@@ -351,6 +351,22 @@ class MoodleInternalSniff implements Sniff {
                         }
                     }
                     continue 2;
+                case T_STRING:
+                    if (isset($tokens[$i]['content']) === true) {
+                        // Ignore class_alias as this is no different to declaring a class.
+                        // This will be in the format `class_alias(source, target);` and represented by:
+                        // - T_STRING['content'] = 'class_alias'
+                        // - T_OPEN_PARENTHESIS
+                        // - ...
+                        // - T_CLOSE_PARENTHESIS
+                        if ($tokens[$i]['content'] === 'class_alias') {
+                            $paren = $file->findNext(T_OPEN_PARENTHESIS, ($i + 1));
+                            if ($paren !== false) {
+                                $i = $tokens[$paren]['parenthesis_closer'] + 1;
+                                continue 2;
+                            }
+                        }
+                    }
             }
 
             // Detect and skip over symbols.

--- a/moodle/tests/files_moodleinternal_test.php
+++ b/moodle/tests/files_moodleinternal_test.php
@@ -189,4 +189,44 @@ class files_moodleinternal_test extends local_codechecker_test {
 
         $this->verify_cs_results();
     }
+
+    public function test_moodle_files_moodleinternal_class_alias() {
+        // Contains class_alias, which is not a side-effect.
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.MoodleInternal');
+        $this->set_fixture(__DIR__ . '/fixtures/files/moodleinternal/class_alias.php');
+
+        $this->set_errors([]);
+        $this->set_warnings([]);
+
+        $this->verify_cs_results();
+    }
+
+    public function test_moodle_files_moodleinternal_class_alias_with_additional_sideeffect() {
+        // Contains class_alias, which is not a side-effect.
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.MoodleInternal');
+        $this->set_fixture(__DIR__ . '/fixtures/files/moodleinternal/class_alias_extra.php');
+
+        $this->set_errors([
+            25 => 'Expected MOODLE_INTERNAL check or config.php inclusion',
+        ]);
+        $this->set_warnings([]);
+
+        $this->verify_cs_results();
+    }
+
+    public function test_moodle_files_moodleinternal_class_alias_with_errant_define() {
+        // Contains class_alias, which is not a side-effect.
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Files.MoodleInternal');
+        $this->set_fixture(__DIR__ . '/fixtures/files/moodleinternal/class_alias_defined.php');
+
+        $this->set_errors([]);
+        $this->set_warnings([
+            17 => 'MoodleInternalNotNeeded',
+        ]);
+
+        $this->verify_cs_results();
+    }
 }

--- a/moodle/tests/fixtures/files/moodleinternal/class_alias.php
+++ b/moodle/tests/fixtures/files/moodleinternal/class_alias.php
@@ -1,0 +1,26 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * File containing a class alias and nothing else.
+ *
+ * @package   mod_example
+ * @copyright 2022 Andrew Lyons <andrew@nicols.co.uk>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+class_alias(\mod_example\some\class_name::class, 'mod_example_some_legacy_class_name');
+class_alias(\mod_example\some\other_class::class, 'mod_example_some_legacy_other_class');

--- a/moodle/tests/fixtures/files/moodleinternal/class_alias_defined.php
+++ b/moodle/tests/fixtures/files/moodleinternal/class_alias_defined.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * File containing a class alias and nothing else.
+ *
+ * @package   mod_example
+ * @copyright 2022 Andrew Lyons <andrew@nicols.co.uk>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+class_alias(\mod_example\some\class_name::class, 'mod_example_some_legacy_class_name');
+class_alias(\mod_example\some\other_class::class, 'mod_example_some_legacy_other_class');

--- a/moodle/tests/fixtures/files/moodleinternal/class_alias_extra.php
+++ b/moodle/tests/fixtures/files/moodleinternal/class_alias_extra.php
@@ -1,0 +1,28 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * File containing a class alias and nothing else.
+ *
+ * @package   mod_example
+ * @copyright 2022 Andrew Lyons <andrew@nicols.co.uk>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+class_alias(\mod_example\some\class_name::class, 'mod_example_some_legacy_class_name');
+class_alias(\mod_example\some\other_class::class, 'mod_example_some_legacy_other_class');
+
+var_dump(class_exists('mod_example_some_legacy_class_name'));


### PR DESCRIPTION
A file containing a class_alias should not be considered a side-effect
on its own.

We may want to use these to migrate away from use of lib.php in the
longer term.

Covered with unit tests.