### PR TITLE
Bump to actions/checkout@v3

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -15,7 +15,7 @@ jobs:
           - php: 7.4
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -24,7 +24,7 @@ jobs:
           extensions: ${{ matrix.extensions }}
           ini-values: pcov.directory=moodle
           coverage: pcov
-          tools: composer, phpcpd
+          tools: composer
 
       - name: Install composer dependencies
         run: |
@@ -36,9 +36,8 @@ jobs:
           ./vendor/bin/phplint
 
       - name: PHP Copy/Paste Detector
-        continue-on-error: true # This step will show errors but will not fail
         if: ${{ always() }}
-        run: phpcpd --exclude moodle/tests moodle
+        run: ./vendor/bin/phpcpd --exclude moodle/Tests moodle
 
       - name: Run phpunit
         if: ${{ always() }}

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "mikey179/vfsstream": "^1.6",
         "overtrue/phplint": "^3.0",
         "phpmd/phpmd": "^2.11",
-        "thor-juhasz/phpunit-coverage-check": "^0.3.0"
+        "thor-juhasz/phpunit-coverage-check": "^0.3.0",
+        "sebastian/phpcpd": "^6.0"
     },
     "replace": {
         "moodlehq/moodle-local_codechecker": "3.1.0"


### PR DESCRIPTION
Related to this deprecation of NodeJS 12 for GHA actions:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

While it doesn't affect to this repository, let's bump to the new v3 version now so we keep it updated.