### PR TITLE
Integration test & PHPCompatibility bump to develop#2fb82334

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ matrix.extensions }}
-          ini-values: pcov.directory=moodle
+          ini-values: pcov.directory=moodle, error_reporting=-1, display_errors=On
           coverage: pcov
           tools: composer
 
@@ -46,3 +46,17 @@ jobs:
 
       - name: Test coverage
         run: ./vendor/bin/phpunit-coverage-check -t 80 clover.xml
+
+      - name: Integration tests
+        if: ${{ always() }}
+        run: |
+          # There is one failure (exit with error)
+          vendor/bin/phpcs --standard=moodle moodle/Tests/fixtures/integration_test_ci.php | tee output.txt || [[ $? = 1 ]]
+          grep -q  "PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY" output.txt
+
+          # The failure is fixed (exit with error)
+          vendor/bin/phpcbf --standard=moodle moodle/Tests/fixtures/integration_test_ci.php | tee output.txt || [[ $? = 1 ]]
+          grep -q "A TOTAL OF 1 ERROR WERE FIXED IN 1 FILE" output.txt
+
+          # So, there isn't any failure any more (exit without error)
+          vendor/bin/phpcs --standard=moodle moodle/Tests/fixtures/integration_test_ci.php | tee output.txt && [[ $? = 0 ]]

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     ],
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
-        "squizlabs/php_codesniffer": "^3.6",
-        "phpcompatibility/php-compatibility": "^9.3"
+        "squizlabs/php_codesniffer": "^3.7.1",
+        "phpcompatibility/php-compatibility": "dev-develop#2fb82334"
     },
     "config": {
         "allow-plugins": {

--- a/moodle/Tests/fixtures/integration_test_ci.php
+++ b/moodle/Tests/fixtures/integration_test_ci.php
@@ -1,0 +1,4 @@
+<?php
+// phpcs:disable moodle.Files
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+$arr ['wrong'] = $value;

--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -43,6 +43,8 @@
 
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
 
+    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
+
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
     <rule ref="Squiz.Commenting.EmptyCatchComment"/>
 


### PR DESCRIPTION
Current PHPCompatibility 9.3.5 is old (2019) and it's not PHP 8.1 compliant (neither has many specific sniffs for new versions).

No matter the lack of new releases, the development is active and happening under their "develop" branch. And it supports PHP 8.1, 8.2 and has a good number of Sniffs for those versions.

When trying to run current moodle-cs from other tools (moodle-plugin-ci, from core...) with PHP 8.1 we were getting some deprecated warnings leading to failed (phpcs and phpcbf) executions.

So, here we are:

1. Updating to PHPCompatibility develop#2fb82334
2. Adding some simple integration tests: Ensure that the GH workflow always run the commands (phpcs and phpcbf)) and they work as expected.
3. Add back the `Squiz.Arrays.ArrayBracketSpacing` sniff to the moodle standard. Somehow it was forgotten/missed when moving the standard from codechecker to moodle-cs.

You can see the integration tests failing [here](https://github.com/stronk7/moodle-cs/actions/runs/3904744318), that is this branch with the PHPCompatibility upgrade disabled. Once the upgrade is applied, all tests are passing.

Ciao :-)