### PR TITLE
Prepare the v3.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 
 ## [Unreleased]
 
+## [v3.3.1] - 2023-01-19
+### Fixed
+- Updated the outdated list of valid magic methods.
+
 ## [v3.3.0] - 2023-01-13
 ### Added
 - Enforce the use of `&&` and `||` logical operators, warning about `and` and `or`: `Squiz.Operators.ValidLogicalOperators`
@@ -28,6 +32,7 @@ All features are maintained and no new features have been introduced to either t
 
 All the details about [previous releases] can be found in [local_codechecker](https://github.com/moodlehq/moodle-local_codechecker) own change log.
 
-[Unreleased]: https://github.com/moodlehq/moodle-cs/compare/v3.3.0...main
+[Unreleased]: https://github.com/moodlehq/moodle-cs/compare/v3.3.1...main
+[v3.3.1]: https://github.com/moodlehq/moodle-cs/compare/v3.3.0...v3.3.1
 [v3.3.0]: https://github.com/moodlehq/moodle-cs/compare/v3.2.0...v3.3.0
 [Previous releases]: https://github.com/moodlehq/moodle-local_codechecker/blob/master/CHANGES.md#changes-in-version-400-20220825---welcome-moodle-cs


### PR DESCRIPTION
Please, do not use merge commit for this. Just rebase/squash alternatives, so we can tag 3.3.1 pointing to it.