### PR TITLE
Update composer dependencies to actual ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- Update composer dependencies to current versions, notably PHPCompatibility (70e4ca24).
 
 ## [v3.3.3] - 2023-03-14
 ### Removed

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         }
     ],
     "require": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
-        "squizlabs/php_codesniffer": "^3.7.1",
-        "phpcompatibility/php-compatibility": "dev-develop#2fb82334"
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+        "squizlabs/php_codesniffer": "^3.7.2",
+        "phpcompatibility/php-compatibility": "dev-develop#70e4ca24"
     },
     "config": {
         "allow-plugins": {
@@ -37,9 +37,9 @@
         "source": "https://github.com/moodlehq/moodle-cs"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "mikey179/vfsstream": "^1.6",
-        "overtrue/phplint": "^3.0",
+        "overtrue/phplint": "^3.4.0 | ^9.0.4",
         "phpmd/phpmd": "^2.11",
         "thor-juhasz/phpunit-coverage-check": "^0.3.0",
         "sebastian/phpcpd": "^6.0"


### PR DESCRIPTION
- All them must work for php74 and up.
- More noticeable one being the PHPCompatibility one up to today's 70e4ca24.