### PR TITLE
Forbid unserialize() method.

### DIFF
--- a/moodle/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/moodle/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -18,8 +18,6 @@
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHP;
 
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff as GenericForbiddenFunctionsSniff;
-use PHP_CodeSniffer\Sniffs\Sniff;
-use PHP_CodeSniffer\Files\File;
 
 /**
  * Sniff for debugging and other functions that we don't want used in finished code.
@@ -63,5 +61,6 @@ class ForbiddenFunctionsSniff extends GenericForbiddenFunctionsSniff
         'print_object' => null,
         // Dangerous functions. From coding style.
         'extract'      => null,
+        'unserialize'  => null,
     ];
 }

--- a/moodle/Tests/MoodleStandardTest.php
+++ b/moodle/Tests/MoodleStandardTest.php
@@ -533,6 +533,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
             15 => 0,
             16 => 0,
             17 => 0,
+            20 => 'function unserialize() is forbidden',
             ]);
         $this->setWarnings([]);
 

--- a/moodle/Tests/fixtures/moodle_php_forbiddenfunctions.php
+++ b/moodle/Tests/fixtures/moodle_php_forbiddenfunctions.php
@@ -16,5 +16,6 @@ goto a;
 a: echo 'Goto labels, oh my!'
 b:
 echo 'More goto labels, re-oh my!'
-// Fair enough.
+// Fair enough. Unserialize can be dangerous too, better catch it.
+$a = unserialize($b);
 


### PR DESCRIPTION
Can lead to code execution exploits if not used properly with user supplied data. There are better methods of data exchange.

See also https://github.com/moodle/devdocs/pull/822