### PR TITLE
Revert "Lower the "and" and "or" uses down from error to warning"

### DIFF
--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -56,9 +56,7 @@
     <rule ref="Squiz.Functions.LowercaseFunctionKeywords"/>
     <rule ref="PSR2.Methods.MethodDeclaration"/>
 
-    <rule ref="Squiz.Operators.ValidLogicalOperators">
-        <type>warning</type>
-    </rule>
+    <rule ref="Squiz.Operators.ValidLogicalOperators"/>
 
     <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
     <rule ref="Squiz.PHP.CommentedOutCode">


### PR DESCRIPTION
One year ago we decided to keep these as warnings until August 2023. Now, it's August 2023, hence, moving the uses of "and" and "or" back to error.

This reverts commit c85e30fbbce432a04b5f3ddb39b08b1729499f57.

Fixes #5.