### PR TITLE
Rename MoodleCSBaseTest to MoodleCSBaseTestCase

### DIFF
--- a/moodle/Tests/FilesBoilerPlateCommentTest.php
+++ b/moodle/Tests/FilesBoilerPlateCommentTest.php
@@ -28,7 +28,7 @@ namespace MoodleHQ\MoodleCS\moodle\Tests;
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\BoilerplateCommentSniff
  */
-class FilesBoilerPlateCommentTest extends MoodleCSBaseTest {
+class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase {
 
     public function test_moodle_files_boilerplatecomment_ok() {
         $this->set_standard('moodle');

--- a/moodle/Tests/FilesMoodleInternalTest.php
+++ b/moodle/Tests/FilesMoodleInternalTest.php
@@ -28,7 +28,7 @@ namespace MoodleHQ\MoodleCS\moodle\Tests;
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\MoodleInternalSniff
  */
-class FilesMoodleInternalTest extends MoodleCSBaseTest {
+class FilesMoodleInternalTest extends MoodleCSBaseTestCase {
 
     public function test_moodle_files_moodleinternal_problem() {
         $this->set_standard('moodle');

--- a/moodle/Tests/MoodleCSBaseTestCase.php
+++ b/moodle/Tests/MoodleCSBaseTestCase.php
@@ -39,7 +39,7 @@ namespace MoodleHQ\MoodleCS\moodle\Tests;
  * @copyright  2013 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-abstract class MoodleCSBaseTest extends \PHPUnit\Framework\TestCase {
+abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase {
 
     /**
      * @var string name of the standard to be tested.

--- a/moodle/Tests/MoodleStandardTest.php
+++ b/moodle/Tests/MoodleStandardTest.php
@@ -30,7 +30,7 @@ namespace MoodleHQ\MoodleCS\moodle\Tests;
  *
  * @todo Complete coverage of all Sniffs.
  */
-class MoodleCsStandardTest extends MoodleCSBaseTest {
+class MoodleStandardTest extends MoodleCSBaseTestCase {
 
     /**
      * Test the PSR2.Methods.MethodDeclaration sniff.

--- a/moodle/Tests/MoodleUtilTest.php
+++ b/moodle/Tests/MoodleUtilTest.php
@@ -35,7 +35,7 @@ use org\bovigo\vfs\vfsStream;
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Util\MoodleUtil
  */
-class MoodleUtilTest extends MoodleCSBaseTest {
+class MoodleUtilTest extends MoodleCSBaseTestCase {
 
     /**
      * Unit test for calculateAllComponents.

--- a/moodle/Tests/NamingConventionsValidFunctionNameTest.php
+++ b/moodle/Tests/NamingConventionsValidFunctionNameTest.php
@@ -30,7 +30,7 @@ use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\NamingConventions\ValidFunctionNameSniff
  */
-class NamingConventionsValidFunctionNameTest extends MoodleCSBaseTest {
+class NamingConventionsValidFunctionNameTest extends MoodleCSBaseTestCase {
 
     /**
      * Data provider for self::test_namingconventions_validfunctionname

--- a/moodle/Tests/PHPIncludingFileTest.php
+++ b/moodle/Tests/PHPIncludingFileTest.php
@@ -28,7 +28,7 @@ namespace MoodleHQ\MoodleCS\moodle\Tests;
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHP\IncludingFileSniff
  */
-class PHPIncludingFileTest extends MoodleCSBaseTest {
+class PHPIncludingFileTest extends MoodleCSBaseTestCase {
 
     public function test_php_includingfile() {
         // Define the standard, sniff and fixture to use.

--- a/moodle/Tests/PHPMemberVarScopeTest.php
+++ b/moodle/Tests/PHPMemberVarScopeTest.php
@@ -28,7 +28,7 @@ namespace MoodleHQ\MoodleCS\moodle\Tests;
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHP\MemberVarScopeSniff
  */
-class PHPMemberVarScopeTest extends MoodleCSBaseTest {
+class PHPMemberVarScopeTest extends MoodleCSBaseTestCase {
 
     public function test_php_membervarscope() {
         // Define the standard, sniff and fixture to use.

--- a/moodle/Tests/PHPUnitTestCaseCoversTest.php
+++ b/moodle/Tests/PHPUnitTestCaseCoversTest.php
@@ -30,7 +30,7 @@ use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit\TestCaseCoversSniff
  */
-class PHPUnitTestCaseCoversTest extends MoodleCSBaseTest {
+class PHPUnitTestCaseCoversTest extends MoodleCSBaseTestCase {
 
     /**
      * Data provider for self::test_phpunit_testcasecovers

--- a/moodle/Tests/PHPUnitTestCaseNamesTest.php
+++ b/moodle/Tests/PHPUnitTestCaseNamesTest.php
@@ -30,7 +30,7 @@ use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit\TestCaseNamesSniff
  */
-class PHPUnitTestCaseNamesTest extends MoodleCSBaseTest {
+class PHPUnitTestCaseNamesTest extends MoodleCSBaseTestCase {
 
     /**
      * Data provider for self::test_phpunit_testcasenames

--- a/moodle/Tests/SquizArraysArrayBrackerSpacingTest.php
+++ b/moodle/Tests/SquizArraysArrayBrackerSpacingTest.php
@@ -28,7 +28,7 @@ namespace MoodleHQ\MoodleCS\moodle\Tests;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayBracketSpacingSniff
  */
-class SquizArraysArrayBrackerSpacingTest extends MoodleCSBaseTest {
+class SquizArraysArrayBrackerSpacingTest extends MoodleCSBaseTestCase {
 
     /**
      * Test the Squid.Arrays.ArrayBracketSpacing sniff

--- a/moodle/Tests/SquizOperatorsValidLogicalOperatorsTest.php
+++ b/moodle/Tests/SquizOperatorsValidLogicalOperatorsTest.php
@@ -28,7 +28,7 @@ namespace MoodleHQ\MoodleCS\moodle\Tests;
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\ValidLogicalOperatorsSniff
  */
-class SquizOperatorsValidLogicalOperatorsTest extends MoodleCSBaseTest {
+class SquizOperatorsValidLogicalOperatorsTest extends MoodleCSBaseTestCase {
 
     /**
      * Test the Squid.Arrays.ValidLogicalOperators sniff

--- a/moodle/Tests/WhiteSpaceSpaceAfterCommaTest.php
+++ b/moodle/Tests/WhiteSpaceSpaceAfterCommaTest.php
@@ -28,7 +28,7 @@ namespace MoodleHQ\MoodleCS\moodle\Tests;
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\WhiteSpace\SpaceAfterCommaSniff
  */
-class WhiteSpaceSpaceAfterCommaTest extends MoodleCSBaseTest {
+class WhiteSpaceSpaceAfterCommaTest extends MoodleCSBaseTestCase {
 
     public function test_whitespace_spaceaftercomma() {
         // Define the standard, sniff and fixture to use.

--- a/moodle/Tests/WhiteSpaceWhiteSpaceInStringsTest.php
+++ b/moodle/Tests/WhiteSpaceWhiteSpaceInStringsTest.php
@@ -28,7 +28,7 @@ namespace MoodleHQ\MoodleCS\moodle\Tests;
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\WhiteSpace\WhiteSpaceInStringsSniff
  */
-class WhiteSpaceWhiteSpaceInStringsTest extends MoodleCSBaseTest {
+class WhiteSpaceWhiteSpaceInStringsTest extends MoodleCSBaseTestCase {
 
     public function test_whitespace_whitespaceinstrings() {
         // Define the standard, sniff and fixture to use.


### PR DESCRIPTION
As a safety check, abstract classes are not allowed to end with [Tt]est anymore in PHPUnit 10. We were doing that with the `MoodleCSBaseTest` class, hence moving to `TestCase` suffix.

Also, the `MoodleCSStandardTest` was incorrectly named (not matching the file name that was correct), so
renamed it to `MoodleStandardTest`.

These changes come onboard before start adding APIs support to the standard (first in PHPUnit classes and, once working) to the whole codebase (that's the plan).