### PR TITLE
Check validity of unit test dataProviders

### DIFF
--- a/moodle-extra/ruleset.xml
+++ b/moodle-extra/ruleset.xml
@@ -81,4 +81,19 @@
 
     -->
 
+    <!--
+        Detect issues with Unit Test dataProviders:
+        - private providers
+        - providers which do not exist
+        - providers whose name is prefixed with _test
+        - incorrect casing of dataProvider
+        - dataProviders which do not return an array or Iterable
+        - dataProviders which can be converted to a static method (PHPUnit 10 compatibility)
+    -->
+    <rule ref="moodle.PHPUnit.TestCaseProvider">
+        <properties>
+            <property name="autofixStaticProviders" value="true"/>
+        </properties>
+    </rule>
+
 </ruleset>

--- a/moodle/Sniffs/PHPUnit/TestCaseCoversSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseCoversSniff.php
@@ -49,11 +49,16 @@ class TestCaseCoversSniff implements Sniff {
 
         // Before starting any check, let's look for various things.
 
-        // Get the moodle branch being analysed.
-        $moodleBranch = MoodleUtil::getMoodleBranch($file);
+        // If we aren't checking Moodle 4.0dev (400) and up, nothing to check.
+        // Make and exception for codechecker phpunit tests, so they are run always.
+        if (!MoodleUtil::meetsMinimumMoodleVersion($file, 400) && !MoodleUtil::isUnitTestRunning()) {
+            return; // @codeCoverageIgnore
+        }
 
-        // Detect if we are running PHPUnit.
-        $runningPHPUnit = defined('PHPUNIT_TEST') && PHPUNIT_TEST;
+        // If the file is not a unit test file, nothing to check.
+        if (!MoodleUtil::isUnitTest($file) && !MoodleUtil::isUnitTestRunning()) {
+            return; // @codeCoverageIgnore
+        }
 
         // We have all we need from core, let's start processing the file.
 
@@ -67,24 +72,6 @@ class TestCaseCoversSniff implements Sniff {
         // We only want to do this once per file.
         $prevopentag = $file->findPrevious(T_OPEN_TAG, $pointer - 1);
         if ($prevopentag !== false) {
-            return; // @codeCoverageIgnore
-        }
-
-        // If we aren't checking Moodle 4.0dev (400) and up, nothing to check.
-        // Make and exception for codechecker phpunit tests, so they are run always.
-        if (isset($moodleBranch) && $moodleBranch < 400 && !$runningPHPUnit) {
-            return; // @codeCoverageIgnore
-        }
-
-        // If the file isn't under tests directory, nothing to check.
-        if (stripos($file->getFilename(), '/tests/') === false) {
-            return; // @codeCoverageIgnore
-        }
-
-        // If the file isn't called, _test.php, nothing to check.
-        // Make an exception for codechecker own phpunit fixtures here, allowing any name for them.
-        $fileName = basename($file->getFilename());
-        if (substr($fileName, -9) !== '_test.php' && !$runningPHPUnit) {
             return; // @codeCoverageIgnore
         }
 

--- a/moodle/Sniffs/PHPUnit/TestCaseNamesSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseNamesSniff.php
@@ -68,7 +68,7 @@ class TestCaseNamesSniff implements Sniff {
         $moodleComponent = MoodleUtil::getMoodleComponent($file);
 
         // Detect if we are running PHPUnit.
-        $runningPHPUnit = defined('PHPUNIT_TEST') && PHPUNIT_TEST;
+        $runningPHPUnit = MoodleUtil::isUnitTestRunning();
 
         // We have all we need from core, let's start processing the file.
 
@@ -81,17 +81,11 @@ class TestCaseNamesSniff implements Sniff {
             return; // @codeCoverageIgnore
         }
 
-        // If the file isn't under tests directory, nothing to check.
-        if (stripos($file->getFilename(), '/tests/') === false) {
+        // If the file is not a unit test file, nothing to check.
+        if (!MoodleUtil::isUnitTest($file) && !$runningPHPUnit) {
             return; // @codeCoverageIgnore
         }
-
-        // If the file isn't called, _test.php, nothing to check.
-        // Make an exception for codechecker own phpunit fixtures here, allowing any name for them.
         $fileName = basename($file->getFilename());
-        if (substr($fileName, -9) !== '_test.php' && !$runningPHPUnit) {
-            return; // @codeCoverageIgnore
-        }
 
         // In order to cover the duplicates detection, we need to set some
         // properties (caches) here. It's extremely hard to do

--- a/moodle/Sniffs/PHPUnit/TestCaseProviderSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseProviderSniff.php
@@ -1,0 +1,366 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit;
+
+// phpcs:disable moodle.NamingConventions
+
+use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\FunctionDeclarations;
+
+/**
+ * Checks that a test file has the @coversxxx annotations properly defined.
+ *
+ * @package    local_codechecker
+ * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class TestCaseProviderSniff implements Sniff {
+
+    /**
+     * Whether to autofix static providers.
+     *
+     * @var bool
+     */
+    public $autofixStaticProviders = false;
+
+    /**
+     * Register for open tag (only process once per file).
+     */
+    public function register(): array
+    {
+        return [
+            T_OPEN_TAG,
+        ];
+    }
+
+    /**
+     * Processes php files and perform various checks with file.
+     *
+     * @param File $file The file being scanned.
+     * @param int $pointer The position in the stack.
+     */
+    public function process(File $file, $pointer): void
+    {
+        // Before starting any check, let's look for various things.
+
+        // If we aren't checking Moodle 4.0dev (400) and up, nothing to check.
+        // Make and exception for codechecker phpunit tests, so they are run always.
+        if (!MoodleUtil::meetsMinimumMoodleVersion($file, 400) && !MoodleUtil::isUnitTestRunning()) {
+            return; // @codeCoverageIgnore
+        }
+
+        // If the file is not a unit test file, nothing to check.
+        if (!MoodleUtil::isUnitTest($file) && !MoodleUtil::isUnitTestRunning()) {
+            return; // @codeCoverageIgnore
+        }
+
+        // We have all we need from core, let's start processing the file.
+
+        // Get the file tokens, for ease of use.
+        $tokens = $file->getTokens();
+
+        // In various places we are going to ignore class/method prefixes (private, abstract...)
+        // and whitespace, create an array for all them.
+        $skipTokens = Tokens::$methodPrefixes + [T_WHITESPACE => T_WHITESPACE];
+
+        // Iterate over all the classes (hopefully only one, but that's not this sniff problem).
+        $cStart = $pointer;
+        while ($cStart = $file->findNext(T_CLASS, $cStart + 1)) {
+            $class = $file->getDeclarationName($cStart);
+
+            // Only if the class is extending something.
+            // TODO: We could add a list of valid classes once we have a class-map available.
+            if (!$file->findNext(T_EXTENDS, $cStart + 1, $tokens[$cStart]['scope_opener'])) {
+                continue;
+            }
+
+            // Ignore any classname which does not end in "_test".
+            if (substr($class, -5) !== '_test') {
+                continue;
+            }
+
+            // Iterate over all the methods in the class.
+            $mStart = $cStart;
+            while ($mStart = $file->findNext(T_FUNCTION, $mStart + 1, $tokens[$cStart]['scope_closer'])) {
+                $method = $file->getDeclarationName($mStart);
+
+                // Ignore non test_xxxx() methods.
+                if (strpos($method, 'test_') !== 0) {
+                    continue;
+                }
+
+                // Let's see if the method has any phpdoc block (first non skip token must be end of phpdoc comment).
+                $docPointer = $file->findPrevious($skipTokens, $mStart - 1, null, true);
+
+                // Found a phpdoc block, let's look for @dataProvider tag.
+                if ($tokens[$docPointer]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
+                    $docStart = $tokens[$docPointer]['comment_opener'];
+                    while ($docPointer) { // Let's look upwards, until the beginning of the phpdoc block.
+                        $docPointer = $file->findPrevious(T_DOC_COMMENT_TAG, $docPointer - 1, $docStart);
+                        if ($docPointer) {
+                            $docTag = trim($tokens[$docPointer]['content']);
+                            $docTagLC = strtolower($docTag);
+                            switch ($docTagLC) {
+                                case '@dataprovider':
+                                    // Validate basic syntax (FQCN or ::).
+                                    $this->checkDataProvider($file, $docPointer);
+                                    break;
+                            }
+                        }
+                    }
+                }
+
+                // Advance until the end of the method, if possible, to find the next one quicker.
+                $mStart = $tokens[$mStart]['scope_closer'] ?? $pointer + 1;
+            }
+        }
+    }
+
+    /**
+     * Perform a basic syntax cheking of the values of the @dataProvider tag.
+     *
+     * @param File $file The file being scanned
+     * @param int $pointer pointer to the token that contains the tag. Calculations are based on that.
+     * @return void
+     */
+    protected function checkDataProvider(
+        File $file,
+        int $pointer
+    ) {
+        // Get the file tokens, for ease of use.
+        $tokens = $file->getTokens();
+        $tag = $tokens[$pointer]['content'];
+        $methodName = $tokens[$pointer + 2]['content'];
+        $testPointer = $file->findNext(T_FUNCTION, $pointer + 2);
+        $testName = FunctionDeclarations::getName($file, $testPointer);
+
+        if ($tag !== '@dataProvider') {
+            $fix = $file->addFixableError(
+                'Wrong @dataProvider tag: %s provided, @dataProvider expected',
+                $pointer,
+                'dataProviderNaming',
+                [$tag]
+            );
+
+            if ($fix) {
+                $file->fixer->beginChangeset();
+                $file->fixer->replaceToken($pointer, '@dataProvider');
+                $file->fixer->endChangeset();
+            }
+        }
+
+        if ($tokens[$pointer + 2]['code'] !== T_DOC_COMMENT_STRING) {
+            $file->addError(
+                'Wrong @dataProvider tag specified for test %s, it must be followed by a space and a method name.',
+                $pointer + 2,
+                'dataProviderSyntaxMethodnameMissing',
+                [
+                    $testName,
+                ]
+            );
+
+            // The remaining checks all relate to the method name, so we can't continue.
+            return;
+        }
+
+        // Check that the method name is valid.
+        // It must _not_ start with `test_`.
+        if (substr($methodName, 0, 5) === 'test_') {
+            $file->addError(
+                'Data provider must not start with "test_". "%s" provided.',
+                $pointer + 2,
+                'dataProviderSyntaxMethodnameInvalid',
+                [
+                    $methodName,
+                ]
+            );
+        }
+
+        // Find the method itself.
+        $classPointer = $file->findPrevious(T_CLASS, $pointer - 1);
+        $providerPointer = MoodleUtil::findClassMethodPointer($file, $classPointer, $methodName);
+        if ($providerPointer === null) {
+            $file->addError(
+                'Data provider method "%s" not found.',
+                $pointer + 2,
+                'dataProviderSyntaxMethodNotFound',
+                [
+                    $methodName,
+                ]
+            );
+
+            return;
+        }
+
+        // https://docs.phpunit.de/en/9.6/writing-tests-for-phpunit.html#data-providers
+        // A data provider method must be public and either return an array of arrays
+        // or an object that implements the Iterator interface and yields an array for
+        // each iteration step. For each array that is part of the collection the test
+        // method will be called with the contents of the array as its arguments.
+
+        // Check that the method is public.
+        $methodProps = $file->getMethodProperties($providerPointer);
+        if (!$methodProps['scope_specified']) {
+            $fix = $file->addFixableError(
+                'Data provider method "%s" visibility should be specified.',
+                $providerPointer,
+                'dataProviderSyntaxMethodVisibilityNotSpecified',
+                [
+                    $methodName,
+                ]
+            );
+
+            if ($fix) {
+                $file->fixer->beginChangeset();
+                if ($methodProps['is_static']) {
+                    $staticPointer = $file->findPrevious(T_STATIC, $providerPointer - 1);
+                    $file->fixer->addContentBefore($staticPointer, 'public ');
+                } else {
+                    $file->fixer->addContentBefore($providerPointer, 'public ');
+                }
+                $file->fixer->endChangeset();
+            }
+        } else if ($methodProps['scope'] !== 'public') {
+            $scopePointer = $file->findPrevious(Tokens::$scopeModifiers, $providerPointer - 1);
+            $fix = $file->addFixableError(
+                'Data provider method "%s" must be public.',
+                $scopePointer,
+                'dataProviderSyntaxMethodNotPublic',
+                [
+                    $methodName,
+                ]
+            );
+
+            if ($fix) {
+                $file->fixer->beginChangeset();
+                $file->fixer->replaceToken($scopePointer, 'public');
+                $file->fixer->endChangeset();
+            }
+        }
+
+        // Check the return type.
+        switch ($methodProps['return_type']) {
+            case 'array':
+            case 'Generator':
+            case 'Iterable':
+                // All valid
+                break;
+            default:
+                $file->addError(
+                    'Data provider method "%s" must return an array, a Generator or an Iterable.',
+                    $pointer + 2,
+                    'dataProviderSyntaxMethodInvalidReturnType',
+                    [
+                        $methodName,
+                    ]
+                );
+        }
+
+        // In preparation for PHPUnit 10, we want to recommend that data providers are statically defined.
+        if (!$methodProps['is_static']) {
+            $supportAutomatedFix = true;
+            if (!$this->autofixStaticProviders) {
+                $supportAutomatedFix = false;
+            } else {
+                // We can make this fixable if the method does not contain any `$this`.
+                // Search the body.
+                $currentPointer = $tokens[$providerPointer]['scope_opener'] + 1;
+                $bodyEnd = $tokens[$providerPointer]['scope_closer'] - 1;
+                while ($token = $file->findNext(T_VARIABLE, $currentPointer, $bodyEnd)) {
+                    if ($tokens[$token]['content'] === '$this') {
+                        $supportAutomatedFix = false;
+                        break;
+                    }
+                    $currentPointer = $token + 1;
+                }
+            }
+
+            if (!$supportAutomatedFix) {
+                $file->addWarning(
+                    'Data provider method "%s" will need to be converted to static in future.',
+                    $pointer + 2,
+                    'dataProviderNotStatic',
+                    [
+                        $methodName,
+                    ]
+                );
+            } else {
+                $fix = $file->addFixableWarning(
+                    'Data provider method "%s" will need to be converted to static in future.',
+                    $pointer + 2,
+                    'dataProviderNotStatic',
+                    [
+                        $methodName,
+                    ]
+                );
+
+                if ($fix) {
+                    $file->fixer->beginChangeset();
+                    $file->fixer->addContentBefore($providerPointer, "static ");
+                    $uses = self::findMethodCalls($file, $classPointer, $methodName);
+                    foreach ($uses as $use) {
+                        $file->fixer->replaceToken($use['start'], 'self::' . $methodName);
+                        $file->fixer->replaceToken($use['start'] + 1, '');
+                        $file->fixer->replaceToken($use['start'] + 2, '');
+                    }
+                    $file->fixer->endChangeset();
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Find all calls to a method.
+     * @param File $phpcsFile
+     * @param int $classPtr
+     * @param string $methodName
+     * @return array
+     */
+    protected static function findMethodCalls(
+        File $phpcsFile,
+        int $classPtr,
+        string $methodName
+    ): array
+    {
+        $data = [];
+
+        $mStart = $classPtr;
+        $tokens = $phpcsFile->getTokens();
+        while ($mStart = $phpcsFile->findNext(T_VARIABLE, $mStart + 1, $tokens[$classPtr]['scope_closer'])) {
+            if ($tokens[$mStart]['content'] !== '$this') {
+                continue;
+            }
+            if ($tokens[$mStart + 1]['code'] !== T_OBJECT_OPERATOR) {
+                continue;
+            }
+            if ($tokens[$mStart + 2]['content'] !== $methodName) {
+                continue;
+            }
+
+            $data[] = [
+                'start' => $mStart,
+                'end' => $mStart + 2,
+            ];
+        }
+
+        return $data;
+    }
+}

--- a/moodle/Tests/MoodleCSBaseTestCase.php
+++ b/moodle/Tests/MoodleCSBaseTestCase.php
@@ -80,7 +80,7 @@ abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase {
      *
      * @param string $standard name of the standard to be tested.
      */
-    protected function set_standard(string$standard) {
+    protected function set_standard(string $standard) {
         if (\PHP_CodeSniffer\Util\Standards::isInstalledStandard($standard) === false) {
             // They didn't select a valid coding standard, so help them
             // out by letting them know which standards are installed.

--- a/moodle/Tests/PHPUnitTestCaseProviderTest.php
+++ b/moodle/Tests/PHPUnitTestCaseProviderTest.php
@@ -1,0 +1,152 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Tests;
+
+use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
+
+// phpcs:disable moodle.NamingConventions
+
+/**
+ * Test the TestCaseCoversSniff sniff.
+ *
+ * @package    local_codechecker
+ * @category   test
+ * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit\TestCaseProviderSniff
+ */
+class PHPUnitTestCaseProviderTest extends MoodleCSBaseTestCase {
+
+    /**
+     * Data provider for self::test_phpunit_test_providers
+     */
+    public function provider_phpunit_data_providers() {
+        return [
+            'Correct' => [
+                'fixture' => 'fixtures/phpunit/provider/correct_test.php',
+                'errors' => [],
+                'warnings' => [],
+            ],
+            'Provider Casing' => [
+                'fixture' => 'fixtures/phpunit/provider/provider_casing_test.php',
+                'errors' => [
+                    6 => 'Wrong @dataProvider tag: @dataprovider provided, @dataProvider expected',
+                ],
+                'warnings' => [
+                ],
+            ],
+            'Provider Visibility' => [
+                'fixture' => 'fixtures/phpunit/provider/provider_visibility_test.php',
+                'errors' => [
+                    12 => 'Data provider method "provider" must be public.',
+                    23 => 'Data provider method "provider_without_visibility" visibility should be specified.',
+                    34 => 'Data provider method "static_provider_without_visibility" visibility should be specified.',
+                ],
+                'warnings' => [
+                    17 => 'Data provider method "provider_without_visibility" will need to be converted to static in future.',
+                ],
+            ],
+            'Provider Naming conflicts with test names' => [
+                'fixture' => 'fixtures/phpunit/provider/provider_prefix_test.php',
+                'errors' => [
+                    6 => 'Data provider must not start with "test_". "test_provider" provided.',
+                ],
+                'warnings' => [
+                ],
+            ],
+            'Static Providers' => [
+                'fixture' => 'fixtures/phpunit/provider/static_providers_test.php',
+                'errors' => [
+                ],
+                'warnings' => [
+                    12 => 'Data provider method "fixable_provider" will need to be converted to static in future.',
+                    23 => 'Data provider method "unfixable_provider" will need to be converted to static in future.',
+                    34 => 'Data provider method "partially_fixable_provider" will need to be converted to static in future.',
+                ],
+            ],
+            'Static Providers Applying fixes' => [
+                'fixture' => 'fixtures/phpunit/provider/static_providers_fix_test.php',
+                'errors' => [
+                ],
+                'warnings' => [
+                    13 => 'Data provider method "fixable_provider" will need to be converted to static in future.',
+                    24 => 'Data provider method "unfixable_provider" will need to be converted to static in future.',
+                    35 => 'Data provider method "partially_fixable_provider" will need to be converted to static in future.',
+                ],
+            ],
+            'Provider Return Type checks' => [
+                'fixture' => 'fixtures/phpunit/provider/provider_returntype_test.php',
+                'errors' => [
+                    6 => 'Data provider method "provider_no_return" must return an array, a Generator or an Iterable.',
+                    17 => 'Data provider method "provider_wrong_return" must return an array, a Generator or an Iterable.',
+                    28 => 'Data provider method "provider_returns_generator" must return an array, a Generator or an Iterable.',
+                    41 => 'Data provider method "provider_returns_iterator" must return an array, a Generator or an Iterable.',
+                ],
+                'warnings' => [
+                ],
+            ],
+            'Provider not found' => [
+                'fixture' => 'fixtures/phpunit/provider/provider_not_found_test.php',
+                'errors' => [
+                    6 => 'Data provider method "provider" not found.',
+                    14 => 'Wrong @dataProvider tag specified for test test_two, it must be followed by a space and a method name.',
+                ],
+                'warnings' => [
+                ],
+            ],
+            'Complex test with multiple classes' => [
+                'fixture' => 'fixtures/phpunit/provider/complex_provider_test.php',
+                'errors' => [
+                    7 => 'Data provider method "provider" not found.',
+                ],
+                'warnings' => [
+                    14 => 'Data provider method "second_provider" will need to be converted to static in future.',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test the moodle.PHPUnit.TestCaseCovers sniff
+     *
+     * @param string $fixture relative path to fixture to use.
+     * @param array $errors array of errors expected.
+     * @param array $warnings array of warnings expected.
+     * @dataProvider provider_phpunit_data_providers
+     */
+    public function test_phpunit_test_providers(
+        string $fixture,
+        array $errors,
+        array $warnings
+    ): void {
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.PHPUnit.TestCaseProvider');
+        $this->set_fixture(__DIR__ . '/' . $fixture);
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $this->set_errors($errors);
+        $this->set_warnings($warnings);
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+}

--- a/moodle/Tests/fixtures/moodleutil/test_with_methods_to_find.php
+++ b/moodle/Tests/fixtures/moodleutil/test_with_methods_to_find.php
@@ -1,0 +1,23 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+class test_with_methods_to_find extends base_test {
+    public function instance_method(): array {
+        return [];
+    }
+    protected function protected_method(): array {
+        return [];
+    }
+    private function private_method(): array {
+        return [];
+    }
+    public static function static_method(): array {
+        return [];
+    }
+    protected static function protected_static_method(): array {
+        return [];
+    }
+    private static function private_static_method(): array {
+        return [];
+    }
+}

--- a/moodle/Tests/fixtures/phpunit/provider/complex_provider_test.php
+++ b/moodle/Tests/fixtures/phpunit/provider/complex_provider_test.php
@@ -1,0 +1,43 @@
+// phpcs:set moodle.PHPUnit.TestCaseProvider autofixStaticProviders true
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+class complex_provider_test extends base_test {
+    /**
+     * @dataProvider provider
+     */
+    public function test_one(): void {
+        // Nothing to test.
+    }
+
+    /**
+     * @dataProvider second_provider
+     */
+    public function test_two(): void {
+        // Nothing to test.
+    }
+
+    public function second_provider(): array {
+        return [];
+    }
+}
+
+class some_other_class extends some_class {
+}
+
+class yet_other_class {
+}
+
+class different_provider_test extends base_test {
+    public function provider(): array {
+        return [];
+    }
+
+    public function second_provider(): array {
+        return [];
+    }
+
+    public function another_method(): array {
+        return $this->second_provider();
+    }
+}

--- a/moodle/Tests/fixtures/phpunit/provider/complex_provider_test.php.fixed
+++ b/moodle/Tests/fixtures/phpunit/provider/complex_provider_test.php.fixed
@@ -1,0 +1,43 @@
+// phpcs:set moodle.PHPUnit.TestCaseProvider autofixStaticProviders true
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+class complex_provider_test extends base_test {
+    /**
+     * @dataProvider provider
+     */
+    public function test_one(): void {
+        // Nothing to test.
+    }
+
+    /**
+     * @dataProvider second_provider
+     */
+    public function test_two(): void {
+        // Nothing to test.
+    }
+
+    public static function second_provider(): array {
+        return [];
+    }
+}
+
+class some_other_class extends some_class {
+}
+
+class yet_other_class {
+}
+
+class different_provider_test extends base_test {
+    public function provider(): array {
+        return [];
+    }
+
+    public function second_provider(): array {
+        return [];
+    }
+
+    public function another_method(): array {
+        return $this->second_provider();
+    }
+}

--- a/moodle/Tests/fixtures/phpunit/provider/correct_test.php
+++ b/moodle/Tests/fixtures/phpunit/provider/correct_test.php
@@ -1,0 +1,22 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+class correct_test extends base_test {
+    /**
+     * Test without a provider
+     */
+    public function test_one(): void {
+        // Nothing to test.
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function test_two(): void {
+        // Nothing to test.
+    }
+
+    public static function provider(): array {
+        return [];
+    }
+}

--- a/moodle/Tests/fixtures/phpunit/provider/provider_casing_test.php
+++ b/moodle/Tests/fixtures/phpunit/provider/provider_casing_test.php
@@ -1,0 +1,15 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+class provider_casing_test extends base_test {
+    /**
+     * @dataprovider provider
+     */
+    public function test_one(): void {
+        // Nothing to test.
+    }
+
+    public static function provider(): array {
+        return [];
+    }
+}

--- a/moodle/Tests/fixtures/phpunit/provider/provider_casing_test.php.fixed
+++ b/moodle/Tests/fixtures/phpunit/provider/provider_casing_test.php.fixed
@@ -1,0 +1,15 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+class provider_casing_test extends base_test {
+    /**
+     * @dataProvider provider
+     */
+    public function test_one(): void {
+        // Nothing to test.
+    }
+
+    public static function provider(): array {
+        return [];
+    }
+}

--- a/moodle/Tests/fixtures/phpunit/provider/provider_not_found_test.php
+++ b/moodle/Tests/fixtures/phpunit/provider/provider_not_found_test.php
@@ -1,0 +1,18 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+class provider_not_found_test extends base_test {
+    /**
+     * @dataProvider provider
+     */
+    public function test_one(): void {
+        // Nothing to test.
+    }
+
+    /**
+     * @dataProvider
+     */
+    public function test_two(): void {
+        // Nothing to test.
+    }
+}

--- a/moodle/Tests/fixtures/phpunit/provider/provider_prefix_test.php
+++ b/moodle/Tests/fixtures/phpunit/provider/provider_prefix_test.php
@@ -1,0 +1,15 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+class provider_prefix_test extends base_test {
+    /**
+     * @dataProvider test_provider
+     */
+    public function test_one(): void {
+        // Nothing to test.
+    }
+
+    public static function test_provider(): array {
+        return [];
+    }
+}

--- a/moodle/Tests/fixtures/phpunit/provider/provider_returntype_test.php
+++ b/moodle/Tests/fixtures/phpunit/provider/provider_returntype_test.php
@@ -1,0 +1,53 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+class provider_returntype_test extends base_test {
+    /**
+     * @dataProvider provider_no_return
+     */
+    public function test_one(): void {
+        // Nothing to test.
+    }
+
+    public static function provider_no_return() {
+        return [];
+    }
+
+    /**
+     * @dataProvider provider_wrong_return
+     */
+    public function test_two(): void {
+        // Nothing to test.
+    }
+
+    public static function provider_wrong_return(): \stdClass {
+        return (object) [];
+    }
+
+    /**
+     * @dataProvider provider_returns_generator
+     */
+    public function test_three(): void {
+        // Nothing to test.
+    }
+
+    public static function provider_returns_generator(): \Generator {
+        yield [
+            'a',
+        ];
+    }
+
+    /**
+     * @dataProvider provider_returns_iterator
+     */
+    public function test_four(): void {
+        // Nothing to test.
+    }
+
+    public static function provider_returns_iterator(): \Iterator {
+        yield [
+            'a',
+        ];
+    }
+
+}

--- a/moodle/Tests/fixtures/phpunit/provider/provider_visibility_test.php
+++ b/moodle/Tests/fixtures/phpunit/provider/provider_visibility_test.php
@@ -1,0 +1,37 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+class provider_visibility_test extends base_test {
+    /**
+     * @dataProvider provider
+     */
+    public function test_one(): void {
+        // Nothing to test.
+    }
+
+    private static function provider(): array {
+        return [];
+    }
+
+    /**
+     * @dataProvider provider_without_visibility
+     */
+    public function test_two(): void {
+        // Nothing to test.
+    }
+
+    function provider_without_visibility(): array {
+        return [];
+    }
+
+    /**
+     * @dataProvider static_provider_without_visibility
+     */
+    public function test_three_two(): void {
+        // Nothing to test.
+    }
+
+    static function static_provider_without_visibility(): array {
+        return [];
+    }
+}

--- a/moodle/Tests/fixtures/phpunit/provider/provider_visibility_test.php.fixed
+++ b/moodle/Tests/fixtures/phpunit/provider/provider_visibility_test.php.fixed
@@ -1,0 +1,37 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+class provider_visibility_test extends base_test {
+    /**
+     * @dataProvider provider
+     */
+    public function test_one(): void {
+        // Nothing to test.
+    }
+
+    public static function provider(): array {
+        return [];
+    }
+
+    /**
+     * @dataProvider provider_without_visibility
+     */
+    public function test_two(): void {
+        // Nothing to test.
+    }
+
+    public function provider_without_visibility(): array {
+        return [];
+    }
+
+    /**
+     * @dataProvider static_provider_without_visibility
+     */
+    public function test_three_two(): void {
+        // Nothing to test.
+    }
+
+    public static function static_provider_without_visibility(): array {
+        return [];
+    }
+}

--- a/moodle/Tests/fixtures/phpunit/provider/static_providers_fix_test.php
+++ b/moodle/Tests/fixtures/phpunit/provider/static_providers_fix_test.php
@@ -1,0 +1,49 @@
+// phpcs:set moodle.PHPUnit.TestCaseProvider autofixStaticProviders true
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// A class with 3 methods, using all the covers options correctly.
+
+/**
+ * @coversDefaultClass \some\namespace\one
+ * @covers ::all()
+ */
+class static_providers_test extends base_test {
+    /**
+     * @dataProvider fixable_provider
+     */
+    public function test_fixable(): void {
+        // Nothing to test.
+    }
+
+    public function fixable_provider(): array {
+        return [];
+    }
+
+    /**
+     * @dataProvider unfixable_provider
+     */
+    public function test_unfixable_provider(): void {
+        // Nothing to test.
+    }
+
+    public function unfixable_provider(): array {
+        return $this->provider();
+    }
+
+    /**
+     * @dataProvider partially_fixable_provider
+     */
+    public function test_partially_fixable(): void {
+        // Nothing to test.
+    }
+
+    public function partially_fixable_provider(): array {
+        $foo = $this->call_something();
+        $foo->bar();
+        $foo();
+        $this();
+        $this;
+        return $this->fixable_provider();
+    }
+}

--- a/moodle/Tests/fixtures/phpunit/provider/static_providers_fix_test.php.fixed
+++ b/moodle/Tests/fixtures/phpunit/provider/static_providers_fix_test.php.fixed
@@ -1,0 +1,49 @@
+// phpcs:set moodle.PHPUnit.TestCaseProvider autofixStaticProviders true
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// A class with 3 methods, using all the covers options correctly.
+
+/**
+ * @coversDefaultClass \some\namespace\one
+ * @covers ::all()
+ */
+class static_providers_test extends base_test {
+    /**
+     * @dataProvider fixable_provider
+     */
+    public function test_fixable(): void {
+        // Nothing to test.
+    }
+
+    public static function fixable_provider(): array {
+        return [];
+    }
+
+    /**
+     * @dataProvider unfixable_provider
+     */
+    public function test_unfixable_provider(): void {
+        // Nothing to test.
+    }
+
+    public function unfixable_provider(): array {
+        return $this->provider();
+    }
+
+    /**
+     * @dataProvider partially_fixable_provider
+     */
+    public function test_partially_fixable(): void {
+        // Nothing to test.
+    }
+
+    public function partially_fixable_provider(): array {
+        $foo = $this->call_something();
+        $foo->bar();
+        $foo();
+        $this();
+        $this;
+        return self::fixable_provider();
+    }
+}

--- a/moodle/Tests/fixtures/phpunit/provider/static_providers_test.php
+++ b/moodle/Tests/fixtures/phpunit/provider/static_providers_test.php
@@ -1,0 +1,46 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// A class with 3 methods, using all the covers options correctly.
+
+/**
+ * @coversDefaultClass \some\namespace\one
+ * @covers ::all()
+ */
+class static_providers_test extends base_test {
+    /**
+     * @dataProvider fixable_provider
+     */
+    public function test_fixable(): void {
+        // Nothing to test.
+    }
+
+    public function fixable_provider(): array {
+        return [];
+    }
+
+    /**
+     * @dataProvider unfixable_provider
+     */
+    public function test_unfixable_provider(): void {
+        // Nothing to test.
+    }
+
+    public function unfixable_provider(): array {
+        return $this->provider();
+    }
+
+    /**
+     * @dataProvider partially_fixable_provider
+     */
+    public function test_partially_fixable(): void {
+        // Nothing to test.
+    }
+
+    public function partially_fixable_provider(): array {
+        $foo = $this->call_something();
+        $foo->bar();
+        $foo();
+        return $this->fixable_provider();
+    }
+}

--- a/moodle/Tests/fixtures/phpunit/provider/static_providers_test.php.fixed
+++ b/moodle/Tests/fixtures/phpunit/provider/static_providers_test.php.fixed
@@ -1,0 +1,46 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// A class with 3 methods, using all the covers options correctly.
+
+/**
+ * @coversDefaultClass \some\namespace\one
+ * @covers ::all()
+ */
+class static_providers_test extends base_test {
+    /**
+     * @dataProvider fixable_provider
+     */
+    public function test_fixable(): void {
+        // Nothing to test.
+    }
+
+    public function fixable_provider(): array {
+        return [];
+    }
+
+    /**
+     * @dataProvider unfixable_provider
+     */
+    public function test_unfixable_provider(): void {
+        // Nothing to test.
+    }
+
+    public function unfixable_provider(): array {
+        return $this->provider();
+    }
+
+    /**
+     * @dataProvider partially_fixable_provider
+     */
+    public function test_partially_fixable(): void {
+        // Nothing to test.
+    }
+
+    public function partially_fixable_provider(): array {
+        $foo = $this->call_something();
+        $foo->bar();
+        $foo();
+        return $this->fixable_provider();
+    }
+}

--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -100,7 +100,15 @@
 
     <rule ref="Zend.Files.ClosingTag"/>
 
-
+    <!--
+        Detect issues with Unit Test dataProviders:
+        - private providers
+        - providers which do not exist
+        - providers whose name is prefixed with _test
+        - incorrect casing of dataProvider
+        - dataProviders which do not return an array or Iterable
+    -->
+    <rule ref="moodle.PHPUnit.TestCaseProvider"/>
 
     <!-- Disable this exact error unless it's approved -->
     <rule ref="moodle.Commenting.InlineComment.SpacingAfter">


### PR DESCRIPTION
This change includes:
- detection of private providers (error)
- detection of providers which do not exist (error)
- detection of incorrect casing of the dataProvider declaration (fixable error)
- detection of providers which do not have a correct return type (fixable error)
- detection of providers which are not static (partially fixable warning)
- detection of providers whose names start with test_ (error)