### PR TITLE
Require trailing commas in multi-line Arrays

### DIFF
--- a/moodle-extra/ruleset.xml
+++ b/moodle-extra/ruleset.xml
@@ -48,9 +48,6 @@
     <!-- Detect duplicate array keys -->
     <rule ref="Universal.Arrays.DuplicateArrayKey"/>
 
-    <!-- Require a comma after the last element in a multi-line array, but prevent in a single-line array definition -->
-    <rule ref="NormalizedArrays.Arrays.CommaAfterLast"/>
-
     <!-- Disallow use of list() instead of [] -->
     <rule ref="Universal.Lists.DisallowLongListSyntax"/>
 

--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -13,6 +13,16 @@
         <type>warning</type>
     </rule>
 
+    <!--
+        Trailing commas in multi-line Arrays.
+
+        Agreed in MDLSITE-5873 on 21 May 2020.
+        Affects all major branches since Moodle 3.9.
+
+        Require a comma after the last element in a multi-line array, but prevent in a single-line array definition
+    -->
+    <rule ref="NormalizedArrays.Arrays.CommaAfterLast"/>
+
     <rule ref="Generic.Classes.DuplicateClassName"/>
     <rule ref="Generic.Classes.OpeningBraceSameLine"/>
 
@@ -89,6 +99,8 @@
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
 
     <rule ref="Zend.Files.ClosingTag"/>
+
+
 
     <!-- Disable this exact error unless it's approved -->
     <rule ref="moodle.Commenting.InlineComment.SpacingAfter">


### PR DESCRIPTION
Fixes #25

This was agreed in May 2020, so all branches since Moodle 3.9 should use this. We can now safely make this mainstream and not just in moodle-extra.