### PR TITLE
Handle the case where an abstract testcase exists

### DIFF
--- a/moodle/Sniffs/PHPUnit/TestCaseNamesSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseNamesSniff.php
@@ -29,7 +29,7 @@ namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit;
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\FunctionDeclarations;
 
 class TestCaseNamesSniff implements Sniff {
 
@@ -122,6 +122,16 @@ class TestCaseNamesSniff implements Sniff {
             $method = '';
             $methodFound = false;
             while ($mStart = $file->findNext(T_FUNCTION, $pointer, $tokens[$cStart]['scope_closer'])) {
+                $info = FunctionDeclarations::getProperties($file, $mStart);
+                if (!$info['has_body']) {
+                    // Some methods have no body (for example, abstract).
+                    // Therefore there is no scope_closer
+                    // There may be a parenthesis closer, or a semi-colon,
+                    // but there is no easy way to determine this.
+                    // Fall back to finding the next function based on the pointer position.
+                    $pointer = $mStart + 1;
+                    continue;
+                }
                 $pointer = $tokens[$mStart]['scope_closer']; // Next iteration look after the end of current method.
                 if (strpos($file->getDeclarationName($mStart), 'test_') === 0) {
                     $methodFound = true;

--- a/moodle/Tests/PHPUnitTestCaseNamesTest.php
+++ b/moodle/Tests/PHPUnitTestCaseNamesTest.php
@@ -52,6 +52,11 @@ class PHPUnitTestCaseNamesTest extends MoodleCSBaseTestCase {
                 ],
                 'warnings' => [],
             ],
+            'Abstract methods in a testcase' => [
+                'fixture' => 'fixtures/phpunit/testcasenames_with_abstract_test.php',
+                'errors' => [],
+                'warnings' => [],
+            ],
             'NoMatch' => [
                 'fixture' => 'fixtures/phpunit/testcasenames_nomatch.php',
                 'errors' => [],

--- a/moodle/Tests/fixtures/phpunit/testcasenames_with_abstract_test.php
+++ b/moodle/Tests/fixtures/phpunit/testcasenames_with_abstract_test.php
@@ -1,0 +1,17 @@
+<?php
+namespace local_codechecker;
+defined("MOODLE_INTERNAL") || die(); // Make this always the 1st line in all CS fixtures.
+
+/**
+ * Class which is an abstract testcase.
+ */
+abstract class testcasenames_with_abstract_test extends base_test {
+    abstract public function generate_test_data(): array;
+
+    abstract public function generate_example_data();
+
+    public function test_something(): void {
+        $data = $this->generate_test_data();
+        // Test something with the data.
+    }
+}


### PR DESCRIPTION
Abstract methods were not handled properly. A method with no body has no scope_closer.

Discovered in a real world issue!