### PR TITLE
Abstract tests do not need coverage data

### DIFF
--- a/moodle/Tests/fixtures/phpunit/testcasecovers_skipped.php
+++ b/moodle/Tests/fixtures/phpunit/testcasecovers_skipped.php
@@ -23,3 +23,10 @@ class something3_test extends base_test {
         // Nothing to test.
     }
 }
+
+// An abstract class is not inspected.
+abstract class some_abstract_testcase extends base_test {
+    public function test_something() {
+        // Nothing to test.
+    }
+}


### PR DESCRIPTION
Coverage data for abstract classes is optional. In most cases it will make sense to belong to the concrete class that implements it.