### PR TITLE
Apply for export-ignore towards better release packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,16 @@
+# Ignore all these files for release packages.
+# Using Composer `--prefer-dist` will not include these files.
+# Use `--prefer-source` to include them.
+# See https://blog.madewithlove.be/post/gitattributes/
+.gitattributes   export-ignore
+.gitignore       export-ignore
+.phplint.yml     export-ignore
+CHANGELOG.md     export-ignore
+phpunit.xml.dist export-ignore
+README.md        export-ignore
+/.github         export-ignore
+/moodle/Tests    export-ignore
+
 # The generic_files_linendings test is checking for crlf line endings and warns about them.
 # This must be specified as a .gitattribute to prevent git updating it to be LF on commit.
 /moodle/Tests/fixtures/generic_files_lineendings.php eol=crlf


### PR DESCRIPTION
When used as a dependency in other projects, we don't want the release packages to include any development file. This includes CI files, test files, docs...

This is useful to both:
- Reduce the package sizes noticeably.
- Ensure that composer, by default, (--prefer-dist) doesn't include them. If anybody prefers to get the complete version they always can use --prefer-source or clone the repository.

This is considered good practice, as far as there can be problems with tests and other stuff when the dependencies include everything.