### PR TITLE
Allow missing commas when last element is same line than closer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
         "squizlabs/php_codesniffer": "^3.7.2",
-        "phpcsstandards/phpcsextra": "^1.1.0",
+        "phpcsstandards/phpcsextra": "1.x-dev",
         "phpcompatibility/php-compatibility": "dev-develop#0a17f9ed"
     },
     "config": {

--- a/moodle/Tests/NormalizedArraysArraysCommaAfterLastTest.php
+++ b/moodle/Tests/NormalizedArraysArraysCommaAfterLastTest.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Tests;
+
+// phpcs:disable moodle.NamingConventions
+
+/**
+ * Test the \PHPCSExtra\NormalizedArrays\Sniffs\Arrays\CommaAfterLastSniff sniff.
+ *
+ * @package    local_codechecker
+ * @category   test
+ * @copyright  2023 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \PHPCSExtra\NormalizedArrays\Sniffs\Arrays\CommaAfterLastSniff
+ */
+class NormalizedArraysArraysCommaAfterLastTest extends MoodleCSBaseTestCase
+{
+    /**
+     * Test the NormalizedArrays.Arrays.CommaAfterLast sniff
+     */
+    public function testNormalizedArraysArraysCommaAfterLast() {
+
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('NormalizedArrays.Arrays.CommaAfterLast');
+        $this->set_fixture(__DIR__ . '/fixtures/normalizedarrays_arrays_commaafterlast.php');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $this->set_errors([
+            79 => '@Source: NormalizedArrays.Arrays.CommaAfterLast.FoundSingleLine',
+            82 => '@Source: NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLine',
+            87 => 1,
+            95 => 1,
+            97 => 1,
+        ]);
+        $this->set_warnings([]);
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+}

--- a/moodle/Tests/fixtures/normalizedarrays_arrays_commaafterlast.php
+++ b/moodle/Tests/fixtures/normalizedarrays_arrays_commaafterlast.php
@@ -1,0 +1,98 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// Disabling this error as we do in our ruleset, so tests run the same.
+// phpcs:disable NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine
+
+// All these are good / valid code.
+
+$good = [1, 2, 3, 4];
+
+$good = [
+    1, 2, 3, 4,
+];
+
+$good = [1 => 1, 2 => 2, 3 => 3, 4 => 4];
+
+$good = [
+    1 => 1, 2 => 2, 3 => 3, 4 => 4,
+];
+
+$good = [1, 2, // This is good for us, when the closing bracket is on the same line.
+    3, 4];
+
+$good = [ // This is good, though they are no-sense. The Sniff only looks for "found" commas when set to "prevent".
+    1, 2,
+    3, 4,];
+
+$good = [
+    1, 2,
+    3, 4,
+];
+
+$good = [1 => 1, 2 => 2,
+    3 => 3, 4 => 4];
+
+$good = [1 => 1, 2 => 2,
+    3 => 3, 4 => 4,];
+
+$good = [
+    1 => 1, 2 => 2,
+    3 => 3, 4 => 4,
+];
+
+$good = [
+    1 => 1, 2 => 2,
+    3 => 3, 4 => 4,];
+
+$good = [1 => [1 => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4], 5 => 5];
+
+$good = [1 => [1 => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4],
+5 => 5];
+
+$good = [1 => [
+    1 => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4,
+],
+5 => 5];
+
+$good = [
+    1 => [
+        1 => 1,
+        2 => 2,
+        3 => 3,
+        4 => 4,
+    ],
+    5 => 5,
+];
+
+// All these are bad / invalid code.
+
+$found = [ 1, 2, 3, 4, ];
+
+$missing = [
+    1, 2, 3, 4
+];
+
+$missing = [
+    1, 2,
+    3, 4
+];
+
+$missing = [
+    1 => [
+        1 => 1,
+        2 => 2,
+        3 => 3,
+        4 => 4
+    ],
+    5 => 5
+];

--- a/moodle/Tests/fixtures/normalizedarrays_arrays_commaafterlast.php.fixed
+++ b/moodle/Tests/fixtures/normalizedarrays_arrays_commaafterlast.php.fixed
@@ -1,0 +1,98 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// Disabling this error as we do in our ruleset, so tests run the same.
+// phpcs:disable NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine
+
+// All these are good / valid code.
+
+$good = [1, 2, 3, 4];
+
+$good = [
+    1, 2, 3, 4,
+];
+
+$good = [1 => 1, 2 => 2, 3 => 3, 4 => 4];
+
+$good = [
+    1 => 1, 2 => 2, 3 => 3, 4 => 4,
+];
+
+$good = [1, 2, // This is good for us, when the closing bracket is on the same line.
+    3, 4];
+
+$good = [ // This is good, though they are no-sense. The Sniff only looks for "found" commas when set to "prevent".
+    1, 2,
+    3, 4,];
+
+$good = [
+    1, 2,
+    3, 4,
+];
+
+$good = [1 => 1, 2 => 2,
+    3 => 3, 4 => 4];
+
+$good = [1 => 1, 2 => 2,
+    3 => 3, 4 => 4,];
+
+$good = [
+    1 => 1, 2 => 2,
+    3 => 3, 4 => 4,
+];
+
+$good = [
+    1 => 1, 2 => 2,
+    3 => 3, 4 => 4,];
+
+$good = [1 => [1 => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4], 5 => 5];
+
+$good = [1 => [1 => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4],
+5 => 5];
+
+$good = [1 => [
+    1 => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4,
+],
+5 => 5];
+
+$good = [
+    1 => [
+        1 => 1,
+        2 => 2,
+        3 => 3,
+        4 => 4,
+    ],
+    5 => 5,
+];
+
+// All these are bad / invalid code.
+
+$found = [ 1, 2, 3, 4 ];
+
+$missing = [
+    1, 2, 3, 4,
+];
+
+$missing = [
+    1, 2,
+    3, 4,
+];
+
+$missing = [
+    1 => [
+        1 => 1,
+        2 => 2,
+        3 => 3,
+        4 => 4,
+    ],
+    5 => 5,
+];

--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -21,7 +21,9 @@
 
         Require a comma after the last element in a multi-line array, but prevent in a single-line array definition
     -->
-    <rule ref="NormalizedArrays.Arrays.CommaAfterLast"/>
+    <rule ref="NormalizedArrays.Arrays.CommaAfterLast">
+        <exclude name="NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine" />
+    </rule>
 
     <rule ref="Generic.Classes.DuplicateClassName"/>
     <rule ref="Generic.Classes.OpeningBraceSameLine"/>


### PR DESCRIPTION
Comes with some tests to ensure that the case is now covered and we are allowing to miss those commas in the last array element when the array closer is in same line.

Fixes #76