### PR TITLE
Allow missing commas when last element is same line than closer (take #2)

### DIFF
--- a/moodle/Sniffs/Arrays/CommaAfterLastSniff.php
+++ b/moodle/Sniffs/Arrays/CommaAfterLastSniff.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * PHPCSExtra, a collection of sniffs and standards for use with PHP_CodeSniffer.
+ *
+ * @package   PHPCSExtra
+ * @copyright 2020 PHPCSExtra Contributors
+ * @license   https://opensource.org/licenses/LGPL-3.0 LGPL3
+ * @link      https://github.com/PHPCSStandards/PHPCSExtra
+ */
+
+namespace MoodleHQ\MoodleCS\moodle\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\Arrays;
+
+/**
+ * Enforce/forbid a comma after the last item in an array declaration.
+ *
+ * Allows for different settings for single-line and multi-line arrays.
+ *
+ * @since 1.0.0
+ */
+final class CommaAfterLastSniff implements Sniff
+{
+
+    /**
+     * Name of the metric.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    const METRIC_NAME = '%s array - comma after last item';
+
+    /**
+     * Whether or not to enforce a comma after the last array item in a single-line array.
+     *
+     * Valid values:
+     * - 'enforce' to always demand a comma after the last item in single-line arrays;
+     * - 'forbid'  to disallow a comma after the last item in single-line arrays;
+     * - 'skip'    to ignore single-line arrays.
+     *
+     * Defaults to: 'forbid'.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    public $singleLine = 'forbid';
+
+    /**
+     * Whether or not to enforce a comma after the last array item in a multi-line array.
+     *
+     * Valid values:
+     * - 'enforce' to always demand a comma after the last item in single-line arrays;
+     * - 'forbid'  to disallow a comma after the last item in single-line arrays;
+     * - 'skip'    to ignore multi-line arrays.
+     *
+     * Defaults to: 'enforce'.
+     *
+     * @since 1.0.0
+     *
+     * @var string
+     */
+    public $multiLine = 'enforce';
+
+    /**
+     * The input values to consider as valid for the public properties.
+     *
+     * Used for input validation.
+     *
+     * @since 1.0.0
+     *
+     * @var array<string, true>
+     */
+    private $validValues = [
+        'enforce' => true,
+        'forbid'  => true,
+        'skip'    => true,
+    ];
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @since 1.0.0
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return Collections::arrayOpenTokensBC();
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @since 1.0.0
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Validate the property input. Invalid values will result in the check being skipped.
+        if (isset($this->validValues[$this->singleLine]) === false) {
+            $this->singleLine = 'skip';
+        }
+        if (isset($this->validValues[$this->multiLine]) === false) {
+            $this->multiLine = 'skip';
+        }
+
+        $openClose = Arrays::getOpenClose($phpcsFile, $stackPtr);
+        if ($openClose === false) {
+            // Short list, real square bracket, live coding or parse error.
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $opener = $openClose['opener'];
+        $closer = $openClose['closer'];
+
+        $action    = $this->singleLine;
+        $phrase    = 'single-line';
+        $errorCode = 'SingleLine';
+        if ($tokens[$opener]['line'] !== $tokens[$closer]['line']) {
+            $action    = $this->multiLine;
+            $phrase    = 'multi-line';
+            $errorCode = 'MultiLine';
+        }
+
+        if ($action === 'skip') {
+            // Nothing to do.
+            return;
+        }
+
+        $lastNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($closer - 1), $opener, true);
+        if ($lastNonEmpty === false || $lastNonEmpty === $opener) {
+            // Bow out: empty array.
+            return;
+        }
+
+        // If the closer is on the same line as the last element, change the error code for multi-line arrays.
+        if ($errorCode === 'MultiLine'
+            && $tokens[$lastNonEmpty]['line'] === $tokens[$closer]['line']
+        ) {
+            $errorCode .= 'CloserSameLine';
+        }
+
+        $isComma = ($tokens[$lastNonEmpty]['code'] === \T_COMMA);
+
+        $phpcsFile->recordMetric(
+            $stackPtr,
+            \sprintf(self::METRIC_NAME, \ucfirst($phrase)),
+            ($isComma === true ? 'yes' : 'no')
+        );
+
+        switch ($action) {
+            case 'enforce':
+                if ($isComma === true) {
+                    return;
+                }
+
+                $error     = 'There should be a comma after the last array item in a %s array.';
+                $errorCode = 'Missing' . $errorCode;
+                $data      = [$phrase];
+                $fix       = $phpcsFile->addFixableError($error, $lastNonEmpty, $errorCode, $data);
+                if ($fix === true) {
+                    $extraContent = ',';
+
+                    if (($tokens[$lastNonEmpty]['code'] === \T_END_HEREDOC
+                        || $tokens[$lastNonEmpty]['code'] === \T_END_NOWDOC)
+                        // Check for indentation, if indented, it's a PHP 7.3+ heredoc/nowdoc.
+                        && $tokens[$lastNonEmpty]['content'] === \ltrim($tokens[$lastNonEmpty]['content'])
+                    ) {
+                        // Prevent parse errors in PHP < 7.3 which doesn't support flexible heredoc/nowdoc.
+                        $extraContent = $phpcsFile->eolChar . $extraContent;
+                    }
+
+                    $phpcsFile->fixer->addContent($lastNonEmpty, $extraContent);
+                }
+
+                return;
+
+            case 'forbid':
+                if ($isComma === false) {
+                    return;
+                }
+
+                $error     = 'A comma after the last array item in a %s array is not allowed.';
+                $errorCode = 'Found' . $errorCode;
+                $data      = [$phrase];
+                $fix       = $phpcsFile->addFixableError($error, $lastNonEmpty, $errorCode, $data);
+                if ($fix === true) {
+                    $start = $lastNonEmpty;
+                    $end   = $lastNonEmpty;
+
+                    // Make sure we're not leaving a superfluous blank line behind.
+                    $prevNonWhitespace = $phpcsFile->findPrevious(\T_WHITESPACE, ($lastNonEmpty - 1), $opener, true);
+                    $nextNonWhitespace = $phpcsFile->findNext(\T_WHITESPACE, ($lastNonEmpty + 1), ($closer + 1), true);
+                    if ($prevNonWhitespace !== false
+                        && $tokens[$prevNonWhitespace]['line'] < $tokens[$lastNonEmpty]['line']
+                        && $nextNonWhitespace !== false
+                        && $tokens[$nextNonWhitespace]['line'] > $tokens[$lastNonEmpty]['line']
+                    ) {
+                        $start = ($prevNonWhitespace + 1);
+                    }
+
+                    $phpcsFile->fixer->beginChangeset();
+
+                    for ($i = $start; $i <= $end; $i++) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                }
+
+                return;
+        }
+    }
+}

--- a/moodle/Tests/NormalizedArraysArraysCommaAfterLastTest.php
+++ b/moodle/Tests/NormalizedArraysArraysCommaAfterLastTest.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Tests;
+
+// phpcs:disable moodle.NamingConventions
+
+/**
+ * Test the \PHPCSExtra\NormalizedArrays\Sniffs\Arrays\CommaAfterLastSniff sniff.
+ *
+ * @package    local_codechecker
+ * @category   test
+ * @copyright  2023 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \PHPCSExtra\NormalizedArrays\Sniffs\Arrays\CommaAfterLastSniff
+ */
+class NormalizedArraysArraysCommaAfterLastTest extends MoodleCSBaseTestCase
+{
+    /**
+     * Test the NormalizedArrays.Arrays.CommaAfterLast sniff
+     */
+    public function testNormalizedArraysArraysCommaAfterLast() {
+
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('NormalizedArrays.Arrays.CommaAfterLast');
+        $this->set_fixture(__DIR__ . '/fixtures/normalizedarrays_arrays_commaafterlast.php');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $this->set_errors([
+            79 => '@Source: NormalizedArrays.Arrays.CommaAfterLast.FoundSingleLine',
+            82 => '@Source: NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLine',
+            87 => 1,
+            95 => 1,
+            97 => 1,
+        ]);
+        $this->set_warnings([]);
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+}

--- a/moodle/Tests/NormalizedArraysArraysCommaAfterLastTest.php
+++ b/moodle/Tests/NormalizedArraysArraysCommaAfterLastTest.php
@@ -26,7 +26,7 @@ namespace MoodleHQ\MoodleCS\moodle\Tests;
  * @copyright  2023 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
- * @covers \PHPCSExtra\NormalizedArrays\Sniffs\Arrays\CommaAfterLastSniff
+ * @covers MoodleHQ\MoodleCS\moodle\Sniffs\Arrays\CommaAfterLastSniff
  */
 class NormalizedArraysArraysCommaAfterLastTest extends MoodleCSBaseTestCase
 {
@@ -37,7 +37,7 @@ class NormalizedArraysArraysCommaAfterLastTest extends MoodleCSBaseTestCase
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
-        $this->set_sniff('NormalizedArrays.Arrays.CommaAfterLast');
+        $this->set_sniff('moodle.Arrays.CommaAfterLast');
         $this->set_fixture(__DIR__ . '/fixtures/normalizedarrays_arrays_commaafterlast.php');
 
         // Define expected results (errors and warnings). Format, array of:
@@ -45,8 +45,8 @@ class NormalizedArraysArraysCommaAfterLastTest extends MoodleCSBaseTestCase
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
         $this->set_errors([
-            79 => '@Source: NormalizedArrays.Arrays.CommaAfterLast.FoundSingleLine',
-            82 => '@Source: NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLine',
+            79 => '@Source: moodle.Arrays.CommaAfterLast.FoundSingleLine',
+            82 => '@Source: moodle.Arrays.CommaAfterLast.MissingMultiLine',
             87 => 1,
             95 => 1,
             97 => 1,

--- a/moodle/Tests/fixtures/normalizedarrays_arrays_commaafterlast.php
+++ b/moodle/Tests/fixtures/normalizedarrays_arrays_commaafterlast.php
@@ -1,0 +1,98 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// Disabling this error as we do in our ruleset, so tests run the same.
+// phpcs:disable NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine
+
+// All these are good / valid code.
+
+$good = [1, 2, 3, 4];
+
+$good = [
+    1, 2, 3, 4,
+];
+
+$good = [1 => 1, 2 => 2, 3 => 3, 4 => 4];
+
+$good = [
+    1 => 1, 2 => 2, 3 => 3, 4 => 4,
+];
+
+$good = [1, 2, // This is good for us, when the closing bracket is on the same line.
+    3, 4];
+
+$good = [ // This is good, though they are no-sense. The Sniff only looks for "found" commas when set to "prevent".
+    1, 2,
+    3, 4,];
+
+$good = [
+    1, 2,
+    3, 4,
+];
+
+$good = [1 => 1, 2 => 2,
+    3 => 3, 4 => 4];
+
+$good = [1 => 1, 2 => 2,
+    3 => 3, 4 => 4,];
+
+$good = [
+    1 => 1, 2 => 2,
+    3 => 3, 4 => 4,
+];
+
+$good = [
+    1 => 1, 2 => 2,
+    3 => 3, 4 => 4,];
+
+$good = [1 => [1 => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4], 5 => 5];
+
+$good = [1 => [1 => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4],
+5 => 5];
+
+$good = [1 => [
+    1 => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4,
+],
+5 => 5];
+
+$good = [
+    1 => [
+        1 => 1,
+        2 => 2,
+        3 => 3,
+        4 => 4,
+    ],
+    5 => 5,
+];
+
+// All these are bad / invalid code.
+
+$found = [ 1, 2, 3, 4, ];
+
+$missing = [
+    1, 2, 3, 4
+];
+
+$missing = [
+    1, 2,
+    3, 4
+];
+
+$missing = [
+    1 => [
+        1 => 1,
+        2 => 2,
+        3 => 3,
+        4 => 4
+    ],
+    5 => 5
+];

--- a/moodle/Tests/fixtures/normalizedarrays_arrays_commaafterlast.php
+++ b/moodle/Tests/fixtures/normalizedarrays_arrays_commaafterlast.php
@@ -2,7 +2,7 @@
 defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
 
 // Disabling this error as we do in our ruleset, so tests run the same.
-// phpcs:disable NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine
+// phpcs:disable moodle.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine
 
 // All these are good / valid code.
 

--- a/moodle/Tests/fixtures/normalizedarrays_arrays_commaafterlast.php.fixed
+++ b/moodle/Tests/fixtures/normalizedarrays_arrays_commaafterlast.php.fixed
@@ -1,0 +1,98 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// Disabling this error as we do in our ruleset, so tests run the same.
+// phpcs:disable NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine
+
+// All these are good / valid code.
+
+$good = [1, 2, 3, 4];
+
+$good = [
+    1, 2, 3, 4,
+];
+
+$good = [1 => 1, 2 => 2, 3 => 3, 4 => 4];
+
+$good = [
+    1 => 1, 2 => 2, 3 => 3, 4 => 4,
+];
+
+$good = [1, 2, // This is good for us, when the closing bracket is on the same line.
+    3, 4];
+
+$good = [ // This is good, though they are no-sense. The Sniff only looks for "found" commas when set to "prevent".
+    1, 2,
+    3, 4,];
+
+$good = [
+    1, 2,
+    3, 4,
+];
+
+$good = [1 => 1, 2 => 2,
+    3 => 3, 4 => 4];
+
+$good = [1 => 1, 2 => 2,
+    3 => 3, 4 => 4,];
+
+$good = [
+    1 => 1, 2 => 2,
+    3 => 3, 4 => 4,
+];
+
+$good = [
+    1 => 1, 2 => 2,
+    3 => 3, 4 => 4,];
+
+$good = [1 => [1 => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4], 5 => 5];
+
+$good = [1 => [1 => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4],
+5 => 5];
+
+$good = [1 => [
+    1 => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4,
+],
+5 => 5];
+
+$good = [
+    1 => [
+        1 => 1,
+        2 => 2,
+        3 => 3,
+        4 => 4,
+    ],
+    5 => 5,
+];
+
+// All these are bad / invalid code.
+
+$found = [ 1, 2, 3, 4 ];
+
+$missing = [
+    1, 2, 3, 4,
+];
+
+$missing = [
+    1, 2,
+    3, 4,
+];
+
+$missing = [
+    1 => [
+        1 => 1,
+        2 => 2,
+        3 => 3,
+        4 => 4,
+    ],
+    5 => 5,
+];

--- a/moodle/Tests/fixtures/normalizedarrays_arrays_commaafterlast.php.fixed
+++ b/moodle/Tests/fixtures/normalizedarrays_arrays_commaafterlast.php.fixed
@@ -2,7 +2,7 @@
 defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
 
 // Disabling this error as we do in our ruleset, so tests run the same.
-// phpcs:disable NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine
+// phpcs:disable moodle.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine
 
 // All these are good / valid code.
 

--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -20,9 +20,14 @@
         Affects all major branches since Moodle 3.9.
 
         Require a comma after the last element in a multi-line array, but prevent in a single-line array definition
-    -->
+
+        TODO: Enable this back and remove our copied Sniff below once PHPCSExtra v1.2.0 is released.
     <rule ref="NormalizedArrays.Arrays.CommaAfterLast">
         <exclude name="NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine" />
+    </rule>
+    -->
+    <rule ref="moodle.Arrays.CommaAfterLast">
+        <exclude name="moodle.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine" />
     </rule>
 
     <rule ref="Generic.Classes.DuplicateClassName"/>

--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -21,7 +21,9 @@
 
         Require a comma after the last element in a multi-line array, but prevent in a single-line array definition
     -->
-    <rule ref="NormalizedArrays.Arrays.CommaAfterLast"/>
+    <rule ref="NormalizedArrays.Arrays.CommaAfterLast">
+        <exclude name="NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine" />
+    </rule>
 
     <rule ref="Generic.Classes.DuplicateClassName"/>
     <rule ref="Generic.Classes.OpeningBraceSameLine"/>


### PR DESCRIPTION
This is a clone of #80 that was closed by mistake...

Comes with some tests to ensure that the case is now covered and we are allowing to miss those commas in the last array element when the array closer is in same line.

Fixes #76

Holding this as draft PR until [PHPCSExtra 1.2.0](https://github.com/PHPCSStandards/PHPCSExtra/milestone/13) is released. Then we'll have to change `composer.json` to point to that new release and this PR will be ready.