### PR TITLE
Move phpcs from squizlabs to phpcsstandards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
-        "squizlabs/php_codesniffer": "^3.7.2",
+        "phpcsstandards/php_codesniffer": "^3.7.2",
         "phpcsstandards/phpcsextra": "^1.1.0",
         "phpcompatibility/php-compatibility": "dev-develop#0a17f9ed"
     },


### PR DESCRIPTION
PHP_Codesniffer is being abandoned by squizlabs. See:

https://github.com/squizlabs/PHP_CodeSniffer/issues/3932 (old org) https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/109 (new org)

So it has been moved (copied "manually", not transferred, not good, squizlabs) to the [PHPCSStandards](https://github.com/PHPCSStandards) organisation.

So this PR just moves us to start using the new organisation. Let's see how things evolve. It would be so great if the new one gets some support... (right now it's a 1-person project, basically).