### PR TITLE
Remove moodle.* sniffs from moodle ruleset

### DIFF
--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -107,21 +107,6 @@
 
     <rule ref="Zend.Files.ClosingTag"/>
 
-    <!--
-        Detect issues with Unit Test dataProviders:
-        - private providers
-        - providers which do not exist
-        - providers whose name is prefixed with _test
-        - incorrect casing of dataProvider
-        - dataProviders which do not return an array or Iterable
-    -->
-    <rule ref="moodle.PHPUnit.TestCaseProvider"/>
-
-    <!--
-        Tests should have a return type. The default return type should be void.
-    -->
-    <rule ref="moodle.PHPUnit.TestReturnType"/>
-
     <!-- Disable this exact error unless it's approved -->
     <rule ref="moodle.Commenting.InlineComment.SpacingAfter">
         <severity>0</severity>
@@ -131,7 +116,6 @@
         Namespace statements, and class imports (use statements) should not use a leading backslash.
     -->
     <rule ref="PSR12.Files.ImportStatement.LeadingSlash"/>
-    <rule ref="moodle.Namespaces.NamespaceStatement"/>
 
     <!-- Let's add the complete PHPCompatibility standard -->
     <rule ref="PHPCompatibility" />


### PR DESCRIPTION
Unless needed to be configured (severity, config option..) own moodle.* sniffs don't have to be added to the standard ruleset.

Fixes #75