### PR TITLE
Lock nikic/php-parser v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
+        "nikic/php-parser": "^4.18",
         "mikey179/vfsstream": "^1.6",
         "overtrue/phplint": "^3.4.0 | ^9.0.4",
         "phpmd/phpmd": "^2.11",


### PR DESCRIPTION
It seems that both phpunit and php-code-coverage have started to accept nikic/php-parser v5, but that's leading to problems with PHP 7.4 runs, that we still support.

See https://github.com/moodlehq/moodle-cs/actions/runs/7487886902 (that was passing 2-3 weeks ago).

So, with this commit, we are locking nikic/php-parser v4

Once we officially make moodle-cs to only support php >= 8.0 we can remove this lock. Issue: #88