### PR TITLE
Avoid abstract infinite loop

### DIFF
--- a/moodle/Sniffs/PHPUnit/TestCaseCoversSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseCoversSniff.php
@@ -209,7 +209,7 @@ class TestCaseCoversSniff implements Sniff {
                 }
 
                 // Advance until the end of the method, if possible, to find the next one quicker.
-                $mStart = $tokens[$mStart]['scope_closer'] ?? $pointer + 1;
+                $mStart = $tokens[$mStart]['scope_closer'] ?? $mStart + 1;
             }
         }
     }

--- a/moodle/Sniffs/PHPUnit/TestCaseNamesSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseNamesSniff.php
@@ -29,7 +29,6 @@ namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit;
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHPCSUtils\Utils\FunctionDeclarations;
 
 class TestCaseNamesSniff implements Sniff {
 
@@ -122,17 +121,8 @@ class TestCaseNamesSniff implements Sniff {
             $method = '';
             $methodFound = false;
             while ($mStart = $file->findNext(T_FUNCTION, $pointer, $tokens[$cStart]['scope_closer'])) {
-                $info = FunctionDeclarations::getProperties($file, $mStart);
-                if (!$info['has_body']) {
-                    // Some methods have no body (for example, abstract).
-                    // Therefore there is no scope_closer
-                    // There may be a parenthesis closer, or a semi-colon,
-                    // but there is no easy way to determine this.
-                    // Fall back to finding the next function based on the pointer position.
-                    $pointer = $mStart + 1;
-                    continue;
-                }
-                $pointer = $tokens[$mStart]['scope_closer']; // Next iteration look after the end of current method.
+                // Next iteration, advance until the end of the method, if possible, to find the next one quicker.
+                $pointer = $tokens[$mStart]['scope_closer'] ?? $mStart + 1;
                 if (strpos($file->getDeclarationName($mStart), 'test_') === 0) {
                     $methodFound = true;
                     $method = $file->getDeclarationName($mStart);

--- a/moodle/Sniffs/PHPUnit/TestCaseProviderSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseProviderSniff.php
@@ -128,7 +128,7 @@ class TestCaseProviderSniff implements Sniff {
                 }
 
                 // Advance until the end of the method, if possible, to find the next one quicker.
-                $mStart = $tokens[$mStart]['scope_closer'] ?? $pointer + 1;
+                $mStart = $tokens[$mStart]['scope_closer'] ?? $mStart + 1;
             }
         }
     }

--- a/moodle/Tests/fixtures/phpunit/testcasenames_with_abstract_test.php
+++ b/moodle/Tests/fixtures/phpunit/testcasenames_with_abstract_test.php
@@ -10,8 +10,5 @@ abstract class testcasenames_with_abstract_test extends base_test {
 
     abstract public function generate_example_data();
 
-    public function test_something(): void {
-        $data = $this->generate_test_data();
-        // Test something with the data.
-    }
+    abstract public function test_something(): void;
 }


### PR DESCRIPTION
Fix a couple of Sniffs that were able to enter into an infinite loop when processing `test_xxx` abstract methods.

Also adds a change to previous guard against that, because it was causing the abstract methods not to be processed.

Covered with tests.

Fixes #93 