### PR TITLE
Allow comments followed by an attribute

### DIFF
--- a/moodle/Sniffs/Commenting/InlineCommentSniff.php
+++ b/moodle/Sniffs/Commenting/InlineCommentSniff.php
@@ -111,6 +111,20 @@ class InlineCommentSniff implements Sniff {
                 T_REQUIRE_ONCE,
             ];
 
+            if ($tokens[$nextToken]['code'] === T_ATTRIBUTE) {
+                // If the next token is an attribute, find the next non-attribute token.
+                // Note: It is possible for the next token to be another attribute, so we need to loop.
+                do {
+                    $token = $tokens[$nextToken];
+                    $nextToken = $phpcsFile->findNext(
+                        Tokens::$emptyTokens,
+                        ($token['attribute_closer'] + 1),
+                        null,
+                        true
+                    );
+                } while ($tokens[$nextToken]['code'] === T_ATTRIBUTE);
+            }
+
             if (in_array($tokens[$nextToken]['code'], $ignore, true) === true) {
                 return;
             }

--- a/moodle/Tests/Sniffs/Commenting/InlineCommentSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/InlineCommentSniffTest.php
@@ -1,0 +1,52 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\Commenting;
+
+use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
+
+// phpcs:disable moodle.NamingConventions
+
+/**
+ * Test the TestCaseNamesSniff sniff.
+ *
+ * @category   test
+ * @copyright  2024 onwards Andrew Lyons <andrew@nicols.co.uk>
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Commenting\InlineCommentSniff
+ */
+class InlineCommentSniffTest extends MoodleCSBaseTestCase
+{
+    public function testCommentBeforeAttribute(): void {
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Commenting.InlineComment');
+        $this->set_fixture(__DIR__ . '/../../fixtures/Commenting/InlineCommentAttributeAfter.php');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $errors = [];
+        $warnings = [];
+        $this->set_errors($errors);
+        $this->set_warnings($warnings);
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+}

--- a/moodle/Tests/fixtures/Commenting/InlineCommentAttributeAfter.php
+++ b/moodle/Tests/fixtures/Commenting/InlineCommentAttributeAfter.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Example class.
+ */
+#[Route()]
+class Example {
+    /** @var moodle_database $db */
+    #[Inject(
+        name: 'moodle_database'
+    )]
+    protected \moodle_database $db;
+
+    /**
+     * Do something with multiple attributes.
+     */
+    #[Attribute()]
+    #[Attribute()]
+    #[Attribute()]
+    public function doSomething() {
+        // Do something.
+    }
+}


### PR DESCRIPTION
Per PER-2.0:

> If a comment docblock is present on a structure that also includes an
> attribute, the comment block MUST come first, followed by any
> attributes, followed by the structure itself. There MUST NOT be any
> blank lines between the docblock and attributes, or the attributes and
> the structure.

https://www.php-fig.org/per/coding-style/#122-placement

Other more attribute-specific Sniffs should test for Attributes and their correctness, but this comment sniff should not add false positives.