### PR TITLE
Fix reported lines in the TestCaseProviderSniff

### DIFF
--- a/moodle/Sniffs/PHPUnit/TestCaseProviderSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseProviderSniff.php
@@ -169,7 +169,7 @@ class TestCaseProviderSniff implements Sniff {
         if ($tokens[$pointer + 2]['code'] !== T_DOC_COMMENT_STRING) {
             $file->addError(
                 'Wrong @dataProvider tag specified for test %s, it must be followed by a space and a method name.',
-                $pointer + 2,
+                $pointer,
                 'dataProviderSyntaxMethodnameMissing',
                 [
                     $testName,
@@ -281,9 +281,10 @@ class TestCaseProviderSniff implements Sniff {
                 // All valid
                 break;
             default:
+                $returnPointer = $file->findNext(T_CLOSE_PARENTHESIS, $providerPointer + 1);
                 $file->addError(
                     'Data provider method "%s" must return an array, a Generator or an Iterable.',
-                    $pointer + 2,
+                    $returnPointer,
                     'dataProviderSyntaxMethodInvalidReturnType',
                     [
                         $methodName,
@@ -313,7 +314,7 @@ class TestCaseProviderSniff implements Sniff {
             if (!$supportAutomatedFix) {
                 $file->addWarning(
                     'Data provider method "%s" will need to be converted to static in future.',
-                    $pointer + 2,
+                    $providerPointer,
                     'dataProviderNotStatic',
                     [
                         $methodName,
@@ -322,7 +323,7 @@ class TestCaseProviderSniff implements Sniff {
             } else {
                 $fix = $file->addFixableWarning(
                     'Data provider method "%s" will need to be converted to static in future.',
-                    $pointer + 2,
+                    $providerPointer,
                     'dataProviderNotStatic',
                     [
                         $methodName,

--- a/moodle/Tests/PHPUnitTestCaseProviderTest.php
+++ b/moodle/Tests/PHPUnitTestCaseProviderTest.php
@@ -66,7 +66,7 @@ class PHPUnitTestCaseProviderTest extends MoodleCSBaseTestCase {
                     34 => 'Data provider method "static_provider_without_visibility" visibility should be specified.',
                 ],
                 'warnings' => [
-                    17 => 'Data provider method "provider_without_visibility" will need to be converted to static in future.',
+                    23 => 'Data provider method "provider_without_visibility" will need to be converted to static in future.',
                 ],
             ],
             'Provider Naming conflicts with test names' => [
@@ -82,9 +82,9 @@ class PHPUnitTestCaseProviderTest extends MoodleCSBaseTestCase {
                 'errors' => [
                 ],
                 'warnings' => [
-                    12 => 'Data provider method "fixable_provider" will need to be converted to static in future.',
-                    23 => 'Data provider method "unfixable_provider" will need to be converted to static in future.',
-                    34 => 'Data provider method "partially_fixable_provider" will need to be converted to static in future.',
+                    18 => 'Data provider method "fixable_provider" will need to be converted to static in future.',
+                    29 => 'Data provider method "unfixable_provider" will need to be converted to static in future.',
+                    40 => 'Data provider method "partially_fixable_provider" will need to be converted to static in future.',
                 ],
             ],
             'Static Providers Applying fixes' => [
@@ -92,18 +92,18 @@ class PHPUnitTestCaseProviderTest extends MoodleCSBaseTestCase {
                 'errors' => [
                 ],
                 'warnings' => [
-                    13 => 'Data provider method "fixable_provider" will need to be converted to static in future.',
-                    24 => 'Data provider method "unfixable_provider" will need to be converted to static in future.',
-                    35 => 'Data provider method "partially_fixable_provider" will need to be converted to static in future.',
+                    19 => 'Data provider method "fixable_provider" will need to be converted to static in future.',
+                    30 => 'Data provider method "unfixable_provider" will need to be converted to static in future.',
+                    41 => 'Data provider method "partially_fixable_provider" will need to be converted to static in future.',
                 ],
             ],
             'Provider Return Type checks' => [
                 'fixture' => 'fixtures/phpunit/provider/provider_returntype_test.php',
                 'errors' => [
-                    6 => 'Data provider method "provider_no_return" must return an array, a Generator or an Iterable.',
-                    17 => 'Data provider method "provider_wrong_return" must return an array, a Generator or an Iterable.',
-                    28 => 'Data provider method "provider_returns_generator" must return an array, a Generator or an Iterable.',
-                    41 => 'Data provider method "provider_returns_iterator" must return an array, a Generator or an Iterable.',
+                    12 => 'Data provider method "provider_no_return" must return an array, a Generator or an Iterable.',
+                    23 => 'Data provider method "provider_wrong_return" must return an array, a Generator or an Iterable.',
+                    34 => 'Data provider method "provider_returns_generator" must return an array, a Generator or an Iterable.',
+                    47 => 'Data provider method "provider_returns_iterator" must return an array, a Generator or an Iterable.',
                 ],
                 'warnings' => [
                 ],
@@ -112,7 +112,7 @@ class PHPUnitTestCaseProviderTest extends MoodleCSBaseTestCase {
                 'fixture' => 'fixtures/phpunit/provider/provider_not_found_test.php',
                 'errors' => [
                     6 => 'Data provider method "provider" not found.',
-                    14 => 'Wrong @dataProvider tag specified for test test_two, it must be followed by a space and a method name.',
+                    13 => 'Wrong @dataProvider tag specified for test test_two, it must be followed by a space and a method name.',
                 ],
                 'warnings' => [
                 ],
@@ -123,7 +123,7 @@ class PHPUnitTestCaseProviderTest extends MoodleCSBaseTestCase {
                     7 => 'Data provider method "provider" not found.',
                 ],
                 'warnings' => [
-                    14 => 'Data provider method "second_provider" will need to be converted to static in future.',
+                    20 => 'Data provider method "second_provider" will need to be converted to static in future.',
                 ],
             ],
         ];


### PR DESCRIPTION
For problems in the provider function declaration it was pointing to the @dataProvider PHPDoc comment, instead of the function.

Now all problems point to the real line they are. It's (was) completely covered with tests, so it should be safe.

Fixes #72