### PR TITLE
Check for correct whitespace in method declarations

### DIFF
--- a/moodle/Sniffs/Methods/MethodDeclarationSpacingSniff.php
+++ b/moodle/Sniffs/Methods/MethodDeclarationSpacingSniff.php
@@ -1,0 +1,170 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * This sniff checks that method declarations are correct, spacing-wise.
+ *
+ * This Sniff completes other Sniffs, already included in the moodle standard,
+ * to ensure that the methods declarations make a correct use of whitespace.
+ * More specifically, it completes the following:
+ * - PSR12.Functions.ReturnTypeDeclaration
+ * - PSR12.Functions.NullableTypeDeclaration
+ * - PSR2.Methods.MethodDeclaration
+ * - Squiz.Whitespace.ScopeKeywordSpacing
+ *
+ * If any of the above Sniffs is disabled, then we'll have to add more
+ * features to this one.
+
+ * @copyright 2024 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace MoodleHQ\MoodleCS\moodle\Sniffs\Methods;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+class MethodDeclarationSpacingSniff extends AbstractScopeSniff
+{
+    public function __construct() {
+        parent::__construct(Tokens::$ooScopeTokens, [T_FUNCTION]);
+    }
+
+    /**
+     * Processes the function tokens within the class.
+     *
+     * @param File $phpcsFile The file where this token was found.
+     * @param int $stackPtr  The position where the token was found.
+     * @param int $currScope The current scope opener token.
+     *
+     * @return void
+     */
+    protected function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope) {
+        // List of tokens that require one space after them.
+        $oneSpaceTokens = [
+            // T_PUBLIC,    // Disabled. Squiz.WhiteSpace.ScopeKeywordSpacing handles it.
+            // T_PROTECTED, // Disabled. Squiz.WhiteSpace.ScopeKeywordSpacing handles it.
+            // T_PRIVATE,   // Disabled. Squiz.WhiteSpace.ScopeKeywordSpacing handles it.
+            // T_STATIC,    // Disabled. Squiz.WhiteSpace.ScopeKeywordSpacing handles it.
+            T_ABSTRACT,
+            T_FINAL,
+            T_FUNCTION,
+        ];
+
+        // List of tokens that require no space after them.
+        $noSpaceTokens = [
+            T_STRING,
+            T_OPEN_PARENTHESIS,
+        ];
+
+        $tokens = $phpcsFile->getTokens();
+
+        // Determine if this is a function which needs to be examined.
+        $conditions = $tokens[$stackPtr]['conditions'];
+        end($conditions);
+        $deepestScope = key($conditions);
+        if ($deepestScope !== $currScope) {
+            return;
+        }
+
+        $methodName = $phpcsFile->getDeclarationName($stackPtr);
+        if ($methodName === null) {
+            // Ignore closures.
+            return;
+        }
+
+        // Find the opening parenthesis of the argument list. That's the last token
+        // that this Sniff is interested in. If, for any reason, the opening parenthesis
+        // is not found, then we'll start from current T_FUNCTION token.
+        $lastToken = $tokens[$stackPtr]['parenthesis_opener'] ?? $stackPtr;
+
+        // These are the tokens that we are interested on.
+        $findTokens = array_merge($oneSpaceTokens, $noSpaceTokens);
+
+        // Find the first token that we are interested in.
+        $foundToken = $phpcsFile->findPrevious($findTokens, $lastToken);
+
+        // Search backwards and examine all the matches found until we change of line.
+        while ($tokens[$foundToken]['line'] === $tokens[$lastToken]['line']) {
+            // If it's a token that requires one space after it, check if there is one.
+            if (in_array($tokens[$foundToken]['code'], $oneSpaceTokens) === true) {
+                $replacement = ' ';
+                if (
+                    $tokens[$foundToken + 1]['code'] === T_WHITESPACE && // We only check whitespace.
+                    $tokens[$foundToken + 1]['content'] !== ' '
+                ) {
+                    $error = 'Expected 1 space after "%s"; %s found';
+                    $data = [
+                        $tokens[$foundToken]['content'],
+                        strlen($tokens[$foundToken + 1]['content']),
+                    ];
+                    $fix = $phpcsFile->addFixableError($error, $foundToken, 'OneExpectedAfter', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken($foundToken + 1, $replacement);
+                    }
+                }
+            }
+
+            // If it's a token that requires no space after it, check if there is none.
+            if (in_array($tokens[$foundToken]['code'], $noSpaceTokens) === true) {
+                $replacement = '';
+                $process = true;
+
+                // We only process T_STRING if it matches the method name.
+                if ($tokens[$foundToken]['code'] === T_STRING) {
+                    if ($tokens[$foundToken]['content'] !== $methodName) {
+                        $process = false;
+                    }
+                }
+
+                // We only process T_OPEN_PARENTHESIS if it has spaces, and only
+                // to get rid of them
+                if ($tokens[$foundToken]['code'] === T_OPEN_PARENTHESIS) {
+                    if (strpos($tokens[$foundToken + 1]['content'], ' ') !== false) {
+                        $replacement = str_replace(' ', '', $tokens[$foundToken + 1]['content']);
+                    } else {
+                        $process = false;
+                    }
+                }
+
+                if (
+                    $tokens[$foundToken + 1]['code'] === T_WHITESPACE && // We only check whitespace.
+                    $tokens[$foundToken + 1]['content'] !== '' &&
+                    $process === true
+                ) {
+                    $error = 'Expected 0 spaces after "%s"; %s found';
+                    $data = [
+                        $tokens[$foundToken]['content'],
+                        strlen($tokens[$foundToken + 1]['content']),
+                    ];
+                    $fix = $phpcsFile->addFixableError($error, $foundToken, 'ZeroExpectedAfter', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken($foundToken + 1, $replacement);
+                    }
+                }
+            }
+
+            // Move to the previous interesting token.
+            $foundToken = $phpcsFile->findPrevious($findTokens, $foundToken - 1);
+        }
+    }
+
+    protected function processTokenOutsideScope(File $phpcsFile, $stackPtr) {
+        return; // @codeCoverageIgnore
+    }
+}

--- a/moodle/Tests/MoodleStandardTest.php
+++ b/moodle/Tests/MoodleStandardTest.php
@@ -33,6 +33,63 @@ namespace MoodleHQ\MoodleCS\moodle\Tests;
 class MoodleStandardTest extends MoodleCSBaseTestCase {
 
     /**
+     * Test the PSR12.Functions.ReturnTypeDeclaration sniff.
+     *
+     * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions\ReturnTypeDeclarationSniff
+     */
+    public function test_psr12_functions_returntypedeclaration() {
+
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('PSR12.Functions.ReturnTypeDeclaration');
+        $this->set_fixture(__DIR__ . '/fixtures/psr12_functions_returntypedeclaration.php');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $errors = [
+            30 => 'SpaceBeforeColon',
+            34 => 'SpaceBeforeReturnType',
+            38 => 'SpaceBeforeReturnType',
+        ];
+        $warnings = [];
+        $this->set_errors($errors);
+        $this->set_warnings($warnings);
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+
+    /**
+     * Test the PSR12.Functions.NullableTypeDeclaration sniff.
+     *
+     * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions\NullableTypeDeclarationSniff
+     */
+    public function test_psr12_functions_nullabletypedeclaration() {
+
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('PSR12.Functions.NullableTypeDeclaration');
+        $this->set_fixture(__DIR__ . '/fixtures/psr12_functions_nullabletypedeclaration.php');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $errors = [
+            17 => 'WhitespaceFound',
+            22 => 3,
+        ];
+        $warnings = [];
+        $this->set_errors($errors);
+        $this->set_warnings($warnings);
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+
+    /**
      * Test the PSR2.Methods.MethodDeclaration sniff.
      *
      * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff

--- a/moodle/Tests/Sniffs/Methods/MethodDeclarationSpacingSniffTest.php
+++ b/moodle/Tests/Sniffs/Methods/MethodDeclarationSpacingSniffTest.php
@@ -1,0 +1,66 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\Methods;
+
+use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
+
+// phpcs:disable moodle.NamingConventions
+
+/**
+ * Test the MethodDeclarationSpacing sniff.
+ *
+ * @copyright  2024 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Methods\MethodDeclarationSpacingSniff
+ */
+class MethodDeclarationSpacingSniffTest extends MoodleCSBaseTestCase
+{
+    public function testMethodDeclarationSpacing(): void {
+        // Define the standard, sniff and fixture to use.
+        $this->set_standard('moodle');
+        $this->set_sniff('moodle.Methods.MethodDeclarationSpacing');
+        $this->set_fixture(__DIR__ . '/../../fixtures/Methods/MethodDeclarationSpacing.php');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $errors = [
+            43 => 4,
+            45 => [
+                'Expected 0 spaces after "("; 2 found',
+                'Expected 0 spaces after "method2"; 2 found',
+                'Expected 1 space after "function"; 2 found',
+                'Expected 1 space after "final"; 2 found',
+            ],
+            49 => [
+                'ZeroExpectedAfter',
+                'ZeroExpectedAfter',
+                'OneExpectedAfter',
+            ],
+            53 => 1,
+            61 => 3,
+        ];
+        $warnings = [];
+        $this->set_errors($errors);
+        $this->set_warnings($warnings);
+
+        // Let's do all the hard work!
+        $this->verify_cs_results();
+    }
+}

--- a/moodle/Tests/fixtures/Methods/MethodDeclarationSpacing.php
+++ b/moodle/Tests/fixtures/Methods/MethodDeclarationSpacing.php
@@ -1,0 +1,64 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// All the methods in this class are correct.
+class correct_methods {
+    abstract public static function method1();
+
+    final public static function method2() {
+        return true;
+    }
+
+    public function method3() {
+        return true;
+    }
+
+    public /* comment */ function method4() {
+        // We don't do anything with with closures.
+        $a = function () {
+            return true;
+        };
+        return true;
+    }
+}
+
+class nested_function_correct {
+    public function getAnonymousClass() {
+        return new class() {
+            public function nested_function() {}
+        };
+    }
+}
+
+// We don't do anything with with global scope functions.
+function   global_function  (  ) {
+    return true;
+}
+
+// All the methods in this class are incorrect.
+// (note that the MethodDeclarationSpacing DOES NOT fix all the
+// keywords in this class, because some are handled by other sniffs.
+// Take a look to the class documentation for more information).
+class incorrect_methods {
+    abstract  public  static  function  method3  (  );
+
+    final  public  static  function  method2  (  ) {
+        return  true;
+    }
+
+    public  function  method3  (  ) {
+        return  true;
+    }
+
+    public function method4 chocolate() {
+        return true;
+    }
+}
+
+class nested_function_incorrect {
+    public function getAnonymousClass() {
+        return new class() {
+            public function  nested_function  (  ) {}
+        };
+    }
+}

--- a/moodle/Tests/fixtures/Methods/MethodDeclarationSpacing.php.fixed
+++ b/moodle/Tests/fixtures/Methods/MethodDeclarationSpacing.php.fixed
@@ -1,0 +1,64 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// All the methods in this class are correct.
+class correct_methods {
+    abstract public static function method1();
+
+    final public static function method2() {
+        return true;
+    }
+
+    public function method3() {
+        return true;
+    }
+
+    public /* comment */ function method4() {
+        // We don't do anything with with closures.
+        $a = function () {
+            return true;
+        };
+        return true;
+    }
+}
+
+class nested_function_correct {
+    public function getAnonymousClass() {
+        return new class() {
+            public function nested_function() {}
+        };
+    }
+}
+
+// We don't do anything with with global scope functions.
+function   global_function  (  ) {
+    return true;
+}
+
+// All the methods in this class are incorrect.
+// (note that the MethodDeclarationSpacing DOES NOT fix all the
+// keywords in this class, because some are handled by other sniffs.
+// Take a look to the class documentation for more information).
+class incorrect_methods {
+    abstract public  static  function method3();
+
+    final public  static  function method2() {
+        return  true;
+    }
+
+    public  function method3() {
+        return  true;
+    }
+
+    public function method4chocolate() {
+        return true;
+    }
+}
+
+class nested_function_incorrect {
+    public function getAnonymousClass() {
+        return new class() {
+            public function nested_function() {}
+        };
+    }
+}

--- a/moodle/Tests/fixtures/psr12_functions_nullabletypedeclaration.php
+++ b/moodle/Tests/fixtures/psr12_functions_nullabletypedeclaration.php
@@ -1,0 +1,24 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// All the return types in this class are correct.
+class correct_methods {
+    public function return_type_nullable_ok(): ?int {
+        return 1;
+    }
+}
+
+function return_type_nullable_ok(): ?int {
+    return 1;
+}
+
+// All the return types in this class have problems..
+class incorrect_methods {
+    public function return_type_nullable_wrong(): ? int {
+        return 1;
+    }
+}
+
+function all_type_nullable_wrong(? int $one, ? int $two): ? int {
+    return 1;
+}

--- a/moodle/Tests/fixtures/psr12_functions_nullabletypedeclaration.php.fixed
+++ b/moodle/Tests/fixtures/psr12_functions_nullabletypedeclaration.php.fixed
@@ -1,0 +1,24 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// All the return types in this class are correct.
+class correct_methods {
+    public function return_type_nullable_ok(): ?int {
+        return 1;
+    }
+}
+
+function return_type_nullable_ok(): ?int {
+    return 1;
+}
+
+// All the return types in this class have problems..
+class incorrect_methods {
+    public function return_type_nullable_wrong(): ?int {
+        return 1;
+    }
+}
+
+function all_type_nullable_wrong(?int $one, ?int $two): ?int {
+    return 1;
+}

--- a/moodle/Tests/fixtures/psr12_functions_returntypedeclaration.php
+++ b/moodle/Tests/fixtures/psr12_functions_returntypedeclaration.php
@@ -1,0 +1,46 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// All the return types in this class are correct.
+class correct_methods {
+    public function no_return_type() {
+        return;
+    }
+
+    public function return_void(): void {
+        return null;
+    }
+
+    public function return_type(): int {
+        return 1;
+    }
+
+    public function return_type_nullable(): ?int {
+        return 1;
+    }
+
+    public function return_type_union(): int|string|null {
+        return null;
+    }
+}
+
+// All the return types in this class have problems..
+class incorrect_methods {
+
+    public function return_wrong_colon_many_spacing()   : int {
+        return 1;
+    }
+
+    public function return_wrong_type_many_spacing():   int {
+        return 1;
+    }
+
+    public function return_wrong_type_no_spacing():int {
+        return 1;
+    }
+
+    // Note this corresponds to the PSR12.Functions.NullableTypeDeclaration Sniff, so it's correct for this fixture.
+    public function return_wrong_nullable_many_spacing(): ?   int {
+        return 1;
+    }
+}

--- a/moodle/Tests/fixtures/psr12_functions_returntypedeclaration.php.fixed
+++ b/moodle/Tests/fixtures/psr12_functions_returntypedeclaration.php.fixed
@@ -1,0 +1,46 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+// All the return types in this class are correct.
+class correct_methods {
+    public function no_return_type() {
+        return;
+    }
+
+    public function return_void(): void {
+        return null;
+    }
+
+    public function return_type(): int {
+        return 1;
+    }
+
+    public function return_type_nullable(): ?int {
+        return 1;
+    }
+
+    public function return_type_union(): int|string|null {
+        return null;
+    }
+}
+
+// All the return types in this class have problems..
+class incorrect_methods {
+
+    public function return_wrong_colon_many_spacing(): int {
+        return 1;
+    }
+
+    public function return_wrong_type_many_spacing(): int {
+        return 1;
+    }
+
+    public function return_wrong_type_no_spacing(): int {
+        return 1;
+    }
+
+    // Note this corresponds to the PSR12.Functions.NullableTypeDeclaration Sniff, so it's correct for this fixture.
+    public function return_wrong_nullable_many_spacing(): ?   int {
+        return 1;
+    }
+}

--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -112,6 +112,10 @@
     -->
     <rule ref="PSR12.Files.ImportStatement.LeadingSlash"/>
 
+    <!-- PSR12 function return types (whitespace handling) -->
+    <rule ref="PSR12.Functions.ReturnTypeDeclaration"/>
+    <rule ref="PSR12.Functions.NullableTypeDeclaration"/>
+
     <!-- Let's add the complete PHPCompatibility standard -->
     <rule ref="PHPCompatibility" />
 


### PR DESCRIPTION
This completes other existing Sniffs that already are doing the job partially:
- Squiz.Whitespace.ScopeKeywordSpacing (for visibility and static).
- PSR2.Methods.MethodDeclaration (for ordering).

What we are doing here is:
- Add the following Sniffs to verify that he return type is being used correctly (space-wise):
   - PSR12.Functions.ReturnTypeDeclaration
   - PSR12.Functions.NullableTypeDeclaration
- Create a new own Sniff: MethodDeclarationSpacingSniff that is in charge of checking all the remaining bits:
   - 1 exact space after "abstract" and "final".
   - 1 exact space after "function".
   - 0 spaces after the function name.
   - 0 spaces after the function open parenthesis.

With everything enabled, we'll get something like this:
```
<     final    abstract     protected static function     kk    ( $a, $b, $c  )   :?  int  {
---
>     final abstract protected static function kk($a, $b, $c  ): ?int {
```

Fixes #22, #99