### PR TITLE
Discard non-variables within double quoted strings

### DIFF
--- a/moodle/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/moodle/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -107,11 +107,13 @@ class ValidVariableNameSniff extends AbstractVariableSniff {
     protected function processVariableInString(File $phpcsfile, $stackptr) {
         $tokens = $phpcsfile->getTokens();
 
-        if (preg_match('/\$([A-Za-z0-9_]+)(\-\>([A-Za-z0-9_]+))?/i',
+        if (preg_match_all('/[^\\\\]\$([A-Za-z0-9_]+)(\-\>([A-Za-z0-9_]+))?/i',
                 $tokens[$stackptr]['content'], $matches)) {
-            $firstvar = $matches[1];
+            $captured = $matches[1];
 
-            $this->validate_moodle_variable_name($firstvar, $phpcsfile, $stackptr);
+            foreach ($captured as $varname) {
+                $this->validate_moodle_variable_name($varname, $phpcsfile, $stackptr);
+            }
         }
     }
 

--- a/moodle/Tests/MoodleStandardTest.php
+++ b/moodle/Tests/MoodleStandardTest.php
@@ -708,7 +708,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
             16 => 0,
             17 => 'The \'var\' keyword is not permitted',
             20 => 'must be all lower-case',
-            21 => 'must not contain underscores',
+            21 => 2,
             22 => array('must be all lower-case', 'must not contain underscores'),
         ));
         $this->set_warnings(array());

--- a/moodle/Tests/fixtures/moodle_namingconventions_variablename.php
+++ b/moodle/Tests/fixtures/moodle_namingconventions_variablename.php
@@ -18,6 +18,11 @@ class foo {
 }
 
 $result = "String: $badPlaceholder1 is a badPlaceholder1";
-$result = "String: $bad_placeholder2";
+$result = "String: $bad_placeholder1 and $bad_placeholder2";
 $result = "String: $REALLY_badplaceholder3";
 $result = "String: $goodplaceholder1";
+$result = "String: $goodplaceholder1 and $goodplaceholder2";
+$result = "String: \$THISISNOTAVARIABLE $strangeone";
+$result = "String: $strangeone \$THISISNOTAVARIABLE";
+$result = "String: \$THISISNOTAVARIABLE $buthisis \$NEITHERTHISIS $butthisistoo";
+$result = 'String: $THISISNOTAVARIABLE $NEITHERTHISIS';

--- a/moodle/Tests/fixtures/moodle_namingconventions_variablename.php.fixed
+++ b/moodle/Tests/fixtures/moodle_namingconventions_variablename.php.fixed
@@ -18,6 +18,11 @@ class foo {
 }
 
 $result = "String: $badplaceholder1 is a badPlaceholder1";
-$result = "String: $badplaceholder2";
+$result = "String: $badplaceholder1 and $badplaceholder2";
 $result = "String: $reallybadplaceholder3";
 $result = "String: $goodplaceholder1";
+$result = "String: $goodplaceholder1 and $goodplaceholder2";
+$result = "String: \$THISISNOTAVARIABLE $strangeone";
+$result = "String: $strangeone \$THISISNOTAVARIABLE";
+$result = "String: \$THISISNOTAVARIABLE $buthisis \$NEITHERTHISIS $butthisistoo";
+$result = 'String: $THISISNOTAVARIABLE $NEITHERTHISIS';


### PR DESCRIPTION
This change fixes a couple of things:

- Stop detecting some literals (escaped $) as variable names.
- Process multiple variables in the same string. Previously only the first variable found was being checked.

Fixes #10