### PR TITLE
Bump squizlabs/php_codesniffer to 3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- Update composer dependencies to current versions, notably `PHP_CodeSniffer` (3.9.0) and `PHPCompatibility` (e5cd2e24).
+
 ## [v3.3.15] - 2024-02-15
 ### Added
 - Function declaration lines are verified to have correct whitespace separation (1 space or 0 spaces) between all their parts.

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     ],
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
-        "squizlabs/php_codesniffer": "^3.8.1",
+        "squizlabs/php_codesniffer": "^3.9.0",
         "phpcsstandards/phpcsextra": "^1.2.1",
-        "phpcompatibility/php-compatibility": "dev-develop#306cd263"
+        "phpcompatibility/php-compatibility": "dev-develop#e5cd2e24"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
Also, bump PHPCompatibility to current dev version (e5cd2e24)

We were using version 9.3.5 that is from December 2019. Since then lots of new sniffs and compatibility with PHP 8.x versions have been provided.

So, while not ideal, let's use the dev version in the mean time.