### PR TITLE
Define moodle-cs own standard, towards better coding

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -41,6 +41,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./vendor/bin/phpcpd --exclude moodle/Tests moodle
 
+      - name: Coding style
+        if: ${{ !cancelled() }}
+        run: ./vendor/bin/phpcs -ps .
+
       - name: Run phpunit
         if: ${{ !cancelled() }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,21 @@
-vendor
+# Composer stuff
 composer.lock
-phpcs.xml
+composer.phar
+vendor
+
+# PHP_CodeSniffer
 .phpcs.xml
+phpcs.xml
+!phpcs.xml.dist
+
+# PHPUnit
 .phpunit.result.cache
 phpunit.xml
-.phplint-cache
 clover.xml
 .phpunit.cache
+
+# PHPlint
+.phplint.cache
+
+# IDEs and editors
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,20 @@
 # Change log
 
 All notable changes to this project will be documented in this file.
-This project adheres to [Semantic Versioning](http://semver.org/).
+This project adheres to [Semantic Versioning](https://semver.org/).
 
-The format of this change log follows the advice given at [Keep a CHANGELOG](http://keepachangelog.com).
+The format of this change log follows the advice given at [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- Add new `moodle.Commenting.Package` sniff to replace those present in moodle-local_moodlecheck.
+- Add new `moodle.Commenting.Category` sniffs to replace those present in moodle-local_moodlecheck.
+- New `phpcs.xml.dist` to enforce the coding style to follow by ´moodle-cs´ itself. Basically, PSR12 ruled. CI verified from now on.
+
 ### Changed
 - Update composer dependencies to current versions, notably `PHP_CodeSniffer` (3.9.0) and `PHPCompatibility` (e5cd2e24).
-
-### Added
-- Add new moodle.Commenting.Package sniffs to replace those present in moodle-local_moodlecheck.
-- Add new moodle.Commenting.Category sniffs to replace those present in moodle-local_moodlecheck.
+- As part of the move to be PSR12 compliant, all the methods used for testing have been converted, without deprecation, to camel case (`setStandard()`, `setSniff()`, ...).
+- ACTION REQUIRED: Any clone/fork using `moodle-cs` and having own tests will need to adapt them to the new method names.
 
 ### Fixed
 - The moodle.Files.MoodleInternal sniff no longer treats Attributes as side-effects.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,8 @@
         }
     ],
     "require": {
+        "php": ">=7.4.0",
+        "ext-json": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
         "squizlabs/php_codesniffer": "^3.9.0",
         "phpcsstandards/phpcsextra": "^1.2.1",

--- a/moodle/Sniffs/Commenting/CategorySniff.php
+++ b/moodle/Sniffs/Commenting/CategorySniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,11 +13,9 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\Commenting;
-
-// phpcs:disable moodle.NamingConventions
 
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 use MoodleHQ\MoodleCS\moodle\Util\Docblocks;
@@ -27,10 +26,10 @@ use PHP_CodeSniffer\Files\File;
  * Checks that all test classes and global functions have appropriate @package tags.
  *
  * @copyright  2024 Andrew Lyons <andrew@nicols.co.uk>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class CategorySniff implements Sniff {
-
+class CategorySniff implements Sniff
+{
     /**
      * Register for open tag (only process once per file).
      */

--- a/moodle/Sniffs/Commenting/InlineCommentSniff.php
+++ b/moodle/Sniffs/Commenting/InlineCommentSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,7 +13,7 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Verifies that inline comments conform to their coding standards.
@@ -20,9 +21,8 @@
  * Based on {@see PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\InlineCommentSniff}
  * with some customizations to suit our very personal rules.
  *
- * @package    local_codechecker
- * @copyright  2012 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2012 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 /**
@@ -35,14 +35,12 @@
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\Commenting;
 
-// phpcs:disable moodle.NamingConventions
-
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class InlineCommentSniff implements Sniff {
-
+class InlineCommentSniff implements Sniff
+{
     /**
      * A list of tokenizers this sniff supports.
      *
@@ -64,9 +62,7 @@ class InlineCommentSniff implements Sniff {
             T_COMMENT,
             T_DOC_COMMENT_OPEN_TAG,
         ];
-
-    }//end register()
-
+    }
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -131,12 +127,12 @@ class InlineCommentSniff implements Sniff {
 
             // Allow phpdoc block before "return new class extends" expressions,
             // we use those anon classes in places like coverage.php files.
-            if ($this->is_return_new_class_extends($phpcsFile, $stackPtr)) {
+            if ($this->isReturnNewClassExtends($phpcsFile, $stackPtr)) {
                 return;
             }
 
             // Allow phpdoc before define() token (see CONTRIB-4150).
-            if ($tokens[$nextToken]['code'] == T_STRING and $tokens[$nextToken]['content'] == 'define') {
+            if ($tokens[$nextToken]['code'] == T_STRING && $tokens[$nextToken]['content'] == 'define') {
                 return;
             }
 
@@ -148,10 +144,11 @@ class InlineCommentSniff implements Sniff {
                 $ignore[]  = T_STRING;
                 $ignore[]  = T_OBJECT_OPERATOR;
                 $nextToken = $phpcsFile->findNext($ignore, ($nextToken + 1), null, true);
-                if ($tokens[$nextToken]['code'] === T_FUNCTION
-                    || $tokens[$nextToken]['code'] === T_CLOSURE
-                    || $tokens[$nextToken]['code'] === T_OBJECT
-                    || $tokens[$nextToken]['code'] === T_PROTOTYPE
+                if (
+                    $tokens[$nextToken]['code'] === T_FUNCTION ||
+                    $tokens[$nextToken]['code'] === T_CLOSURE ||
+                    $tokens[$nextToken]['code'] === T_OBJECT ||
+                    $tokens[$nextToken]['code'] === T_PROTOTYPE
                 ) {
                     return;
                 }
@@ -176,8 +173,10 @@ class InlineCommentSniff implements Sniff {
                 true
             );
             // Is it a @var tag in the comment?
-            if ($tokens[$nextToken]['code'] === T_DOC_COMMENT_TAG &&
-                    $tokens[$nextToken]['content'] == '@var') {
+            if (
+                $tokens[$nextToken]['code'] === T_DOC_COMMENT_TAG &&
+                $tokens[$nextToken]['content'] == '@var'
+            ) {
                 $nextToken = $phpcsFile->findNext(
                     T_DOC_COMMENT_WHITESPACE,
                     ($nextToken + 1),
@@ -221,10 +220,10 @@ class InlineCommentSniff implements Sniff {
                             if (!$nextToken) {
                                 // Not valid type-hinting, specialised error.
                                 $error = 'Inline doc block type-hinting for \'%s\' does not match next list() variables';
-                                $data = array($foundvar);
+                                $data = [$foundvar];
                                 $phpcsFile->addError($error, $stackPtr, 'TypeHintingList', $data);
                             }
-                        } else if ($tokens[$nextToken]['code'] === T_FOREACH) {
+                        } elseif ($tokens[$nextToken]['code'] === T_FOREACH) {
                             // Let's look within the foreach if the variable appear after the 'as' token.
                             $astoken = $phpcsFile->findNext(
                                 T_AS,
@@ -237,13 +236,13 @@ class InlineCommentSniff implements Sniff {
                             if ($tokens[$variabletoken]['content'] !== $foundvar) {
                                 // Not valid type-hinting, specialised error.
                                 $error = 'Inline doc block type-hinting for \'%s\' does not match next foreach() as variable';
-                                $data = array($foundvar, $tokens[$nextToken]['content']);
+                                $data = [$foundvar, $tokens[$nextToken]['content']];
                                 $phpcsFile->addError($error, $stackPtr, 'TypeHintingForeach', $data);
                             }
-                        } else if ($tokens[$nextToken]['content'] !== $foundvar) {
+                        } elseif ($tokens[$nextToken]['content'] !== $foundvar) {
                             // Not valid type-hinting, specialised error.
                             $error = 'Inline doc block type-hinting for \'%s\' does not match next code line \'%s...\'';
-                            $data = array($foundvar, $tokens[$nextToken]['content']);
+                            $data = [$foundvar, $tokens[$nextToken]['content']];
                             $phpcsFile->addError($error, $stackPtr, 'TypeHintingMatch', $data);
                         }
                         return; // Have finished.
@@ -255,7 +254,7 @@ class InlineCommentSniff implements Sniff {
                 $error = 'Inline doc block comments are not allowed; use "// Comment." instead';
                 $phpcsFile->addError($error, $stackPtr, 'DocBlock');
             }
-        }//end if
+        }
 
         if ($tokens[$stackPtr]['content'][0] === '#') {
             $error = 'Perl-style comments are not allowed; use "// Comment." instead';
@@ -275,8 +274,9 @@ class InlineCommentSniff implements Sniff {
             }
 
             // Special case for JS files.
-            if ($tokens[$previousContent]['code'] === T_COMMA
-                || $tokens[$previousContent]['code'] === T_SEMICOLON
+            if (
+                $tokens[$previousContent]['code'] === T_COMMA ||
+                $tokens[$previousContent]['code'] === T_SEMICOLON
             ) {
                 $lastContent = $phpcsFile->findPrevious(T_WHITESPACE, ($previousContent - 1), null, true);
                 if ($tokens[$lastContent]['code'] === T_CLOSE_CURLY_BRACKET) {
@@ -301,14 +301,14 @@ class InlineCommentSniff implements Sniff {
                 $error = 'Comment separators are not allowed to contain other chars buy hyphens (-). Found: (%s)';
                 // Basic clean dupes for notification.
                 $wrongcharsfound = implode(array_keys(array_flip(preg_split('//', $wrongcharsfound, -1, PREG_SPLIT_NO_EMPTY))));
-                $data = array($wrongcharsfound);
+                $data = [$wrongcharsfound];
                 $phpcsFile->addWarning($error, $stackPtr, 'IncorrectCommentSeparator', $data);
             }
             // Verify length between 20 and 120.
             $hyphencount = strlen($matches[1] . $matches[2] . $matches[3]);
-            if ($hyphencount < 20 or $hyphencount > 120) {
+            if ($hyphencount < 20 || $hyphencount > 120) {
                 $error = 'Comment separators length must contain 20-120 chars, %s found';
-                $phpcsFile->addWarning($error, $stackPtr, 'WrongCommentSeparatorLength', array($hyphencount));
+                $phpcsFile->addWarning($error, $stackPtr, 'WrongCommentSeparatorLength', [$hyphencount]);
             }
             // Verify it's the first token in the line.
             $prevToken = $phpcsFile->findPrevious(
@@ -317,9 +317,9 @@ class InlineCommentSniff implements Sniff {
                 null,
                 true
             );
-            if (!empty($prevToken) and $tokens[$prevToken]['line'] == $tokens[$stackPtr]['line']) {
+            if (!empty($prevToken) && $tokens[$prevToken]['line'] == $tokens[$stackPtr]['line']) {
                 $error = 'Comment separators must be the unique text in the line, code found before';
-                $phpcsFile->addWarning($error, $stackPtr, 'WrongCommentCodeFoundBefore', array());
+                $phpcsFile->addWarning($error, $stackPtr, 'WrongCommentCodeFoundBefore', []);
             }
             // Don't want to continue processing the comment separator.
             return;
@@ -349,7 +349,7 @@ class InlineCommentSniff implements Sniff {
 
             $commentTokens[] = $nextComment;
             $lastComment     = $nextComment;
-        }//end while
+        }
 
         $commentText = '';
         foreach ($commentTokens as $lastCommentToken) {
@@ -360,7 +360,7 @@ class InlineCommentSniff implements Sniff {
 
             if ($slashCount > 2) {
                 $error = '%s slashes comments are not allowed; use "// Comment." instead';
-                $data = array($slashCount);
+                $data = [$slashCount];
                 $phpcsFile->addError($error, $lastCommentToken, 'WrongStyle', $data);
             }
 
@@ -393,14 +393,14 @@ class InlineCommentSniff implements Sniff {
                     $comment,
                 ];
                 $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'TabBefore', $data);
-            } else if ($spaceCount === 0) {
+            } elseif ($spaceCount === 0) {
                 $error = 'No space found before comment text; expected "// %s" but found "%s"';
                 $data  = [
                     substr($comment, $slashCount),
                     $comment,
                 ];
                 $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'NoSpaceBefore', $data);
-            } else if ($spaceCount > 1) {
+            } elseif ($spaceCount > 1) {
                 $error = 'Expected 1 space before comment text but found %s; use block comment if you need indentation';
                 $data  = [
                     $spaceCount,
@@ -408,15 +408,15 @@ class InlineCommentSniff implements Sniff {
                     $comment,
                 ];
                 $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', $data);
-            }//end if
+            }
 
             if ($fix === true) {
-                $newComment = '// '.ltrim($tokens[$lastCommentToken]['content'], "/\t ");
+                $newComment = '// ' . ltrim($tokens[$lastCommentToken]['content'], "/\t ");
                 $phpcsFile->fixer->replaceToken($lastCommentToken, $newComment);
             }
 
             $commentText .= trim(substr($tokens[$lastCommentToken]['content'], $slashCount));
-        }//end foreach
+        }
 
         if ($commentText === '') {
             $error = 'Blank comments are not allowed';
@@ -454,7 +454,7 @@ class InlineCommentSniff implements Sniff {
                 $error = 'Inline comments must end in %s';
                 $ender = '';
                 foreach ($acceptedClosers as $closerName => $symbol) {
-                    $ender .= ' '.$closerName.',';
+                    $ender .= ' ' . $closerName . ',';
                 }
 
                 $ender = trim($ender, ' ,');
@@ -500,8 +500,11 @@ class InlineCommentSniff implements Sniff {
                 $type         = end($conditions);
                 $conditionPtr = key($conditions);
 
-                if (($type === T_FUNCTION || $type === T_CLOSURE)
-                    && $tokens[$conditionPtr]['scope_closer'] === $next
+                if (
+                    (
+                        $type === T_FUNCTION ||
+                        $type === T_CLOSURE
+                    ) && $tokens[$conditionPtr]['scope_closer'] === $next
                 ) {
                     $errorCode = 'SpacingAfterAtFunctionEnd';
                 }
@@ -512,7 +515,7 @@ class InlineCommentSniff implements Sniff {
                     if ($tokens[$i]['code'] !== T_WHITESPACE) {
                         return ($lastCommentToken + 1);
                     }
-                } else if ($tokens[$i]['line'] > ($tokens[$lastCommentToken]['line'] + 1)) {
+                } elseif ($tokens[$i]['line'] > ($tokens[$lastCommentToken]['line'] + 1)) {
                     break;
                 }
             }
@@ -531,11 +534,10 @@ class InlineCommentSniff implements Sniff {
 
                 $phpcsFile->fixer->endChangeset();
             }
-        }//end if
+        }
 
         return ($lastCommentToken + 1);
-
-    }//end process()
+    }
 
     /**
      * This looks if there is a valid "return new class extends" expression allowed to have phpdoc block.
@@ -544,7 +546,7 @@ class InlineCommentSniff implements Sniff {
      * @param int $pointer The position in the stack.
      * @return bool true if is an allowed to have phpdoc block return new class code.
      */
-    protected function is_return_new_class_extends(File $file, $pointer) {
+    protected function isReturnNewClassExtends(File $file, $pointer) {
 
         $ignoredtokens = Tokens::$emptyTokens;
 
@@ -576,6 +578,5 @@ class InlineCommentSniff implements Sniff {
 
         // Found a valid "return new class extends" expression, phpdoc block allowed.
         return true;
-    }// end is_return_new_class_extends()
-
-}//end class
+    }
+}

--- a/moodle/Sniffs/Commenting/PackageSniff.php
+++ b/moodle/Sniffs/Commenting/PackageSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,11 +13,9 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\Commenting;
-
-// phpcs:disable moodle.NamingConventions
 
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 use MoodleHQ\MoodleCS\moodle\Util\Docblocks;
@@ -28,10 +27,10 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * Checks that all test classes and global functions have appropriate @package tags.
  *
  * @copyright  2024 Andrew Lyons <andrew@nicols.co.uk>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class PackageSniff implements Sniff {
-
+class PackageSniff implements Sniff
+{
     /**
      * Register for open tag (only process once per file).
      */
@@ -88,7 +87,6 @@ class PackageSniff implements Sniff {
 
             $this->checkDocblock($phpcsFile, $typePtr, $docblock);
         }
-
     }
 
     /**

--- a/moodle/Sniffs/Commenting/TodoCommentSniff.php
+++ b/moodle/Sniffs/Commenting/TodoCommentSniff.php
@@ -27,8 +27,6 @@
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\Commenting;
 
-// phpcs:disable moodle.NamingConventions
-
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/moodle/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/moodle/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,27 +13,24 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Verifies that control statements conform to their coding standards.
  *
  * Based on {@link Squiz_Sniffs_ControlStructures_ControlSignatureSniff}.
  *
- * @package    local_codechecker
  * @copyright  2011 The Open University
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\ControlStructures;
 
-// phpcs:disable moodle.NamingConventions
-
 use PHP_CodeSniffer\Sniffs\AbstractPatternSniff;
 use PHP_CodeSniffer\Files\File;
 
-class ControlSignatureSniff extends AbstractPatternSniff {
-
+class ControlSignatureSniff extends AbstractPatternSniff
+{
     public function __construct() {
         parent::__construct(true);
     }
@@ -40,7 +38,7 @@ class ControlSignatureSniff extends AbstractPatternSniff {
     /** @var array A list of tokenizers this sniff supports. */
 
     protected function getPatterns() {
-        return array(
+        return [
             'try {EOL...} catch (...) {EOL',
             'do {EOL...} while (...);EOL',
             'while (...) {EOL',
@@ -49,6 +47,6 @@ class ControlSignatureSniff extends AbstractPatternSniff {
             'foreach (...) {EOL',
             '} else if (...) {EOL',
             '} else {EOL',
-         );
+         ];
     }
 }

--- a/moodle/Sniffs/Files/BoilerplateCommentSniff.php
+++ b/moodle/Sniffs/Files/BoilerplateCommentSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,26 +13,24 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Checks that each file contains the standard GPL comment.
  *
- * @package    local_codechecker
  * @copyright  2011 The Open University
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\Files;
-
-// phpcs:disable moodle.NamingConventions
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
-class BoilerplateCommentSniff implements Sniff {
-    protected static $comment = array(
+class BoilerplateCommentSniff implements Sniff
+{
+    protected static $comment = [
         "// This file is part of",
         "//",
         "// Moodle is free software: you can redistribute it and/or modify",
@@ -46,9 +45,9 @@ class BoilerplateCommentSniff implements Sniff {
         "//",
         "// You should have received a copy of the GNU General Public License",
         "// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.",
-    );
+    ];
     public function register() {
-        return array(T_OPEN_TAG);
+        return [T_OPEN_TAG];
     }
 
     public function process(File $file, $stackptr) {
@@ -83,8 +82,11 @@ class BoilerplateCommentSniff implements Sniff {
         }
 
         if ($numnewlines > 0) {
-            $file->addError('The opening <?php tag must be followed by exactly one newline.',
-                $stackptr + 1, 'WrongWhitespace');
+            $file->addError(
+                'The opening <?php tag must be followed by exactly one newline.',
+                $stackptr + 1,
+                'WrongWhitespace'
+            );
             return;
         }
         $offset = $stackptr + $numnewlines + 1;
@@ -105,11 +107,16 @@ class BoilerplateCommentSniff implements Sniff {
                 '/^' . preg_quote($line, '/') . '/'
             );
 
-            if ($tokens[$tokenptr]['code'] != T_COMMENT ||
-                    !preg_match($regex, $tokens[$tokenptr]['content'])) {
-
-                $file->addError('Line %s of the opening comment must start "%s".',
-                        $tokenptr, 'WrongLine', array($lineindex + 1, $line));
+            if (
+                $tokens[$tokenptr]['code'] != T_COMMENT ||
+                !preg_match($regex, $tokens[$tokenptr]['content'])
+            ) {
+                $file->addError(
+                    'Line %s of the opening comment must start "%s".',
+                    $tokenptr,
+                    'WrongLine',
+                    [$lineindex + 1, $line]
+                );
             }
         }
     }

--- a/moodle/Sniffs/Files/LineLengthSniff.php
+++ b/moodle/Sniffs/Files/LineLengthSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,14 +13,13 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Checks that lines are no more than 180 chars, ideally 132.
  *
- * @package    local_codechecker
  * @copyright  2011 The Open University
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\Files;
@@ -28,8 +28,8 @@ use PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff as GenericLin
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class LineLengthSniff extends GenericLineLengthSniff {
-
+class LineLengthSniff extends GenericLineLengthSniff
+{
     public function __construct() {
         $this->lineLimit = 132;
         $this->absoluteLineLimit = 180;
@@ -37,8 +37,7 @@ class LineLengthSniff extends GenericLineLengthSniff {
 
     public function process(File $file, $stackptr) {
         // Lang files are allowed to have long lines.
-        if (strpos($file->getFilename(),
-                DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR) !== false) {
+        if (strpos($file->getFilename(), DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR) !== false) {
             return;
         }
         parent::process($file, $stackptr);

--- a/moodle/Sniffs/Files/MoodleInternalSniff.php
+++ b/moodle/Sniffs/Files/MoodleInternalSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,32 +13,30 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Checks that each file contains the standard MOODLE_INTERNAL check or
  * a config.php inclusion.
  *
- * @package    local_codechecker
  * @copyright  2016 Dan Poltawski <dan@moodle.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\Files;
-
-// phpcs:disable moodle.NamingConventions
 
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class MoodleInternalSniff implements Sniff {
+class MoodleInternalSniff implements Sniff
+{
     /**
      * Register for open tag (only process once per file).
      */
     public function register() {
-        return array(T_OPEN_TAG);
+        return [T_OPEN_TAG];
     }
 
     /**
@@ -79,13 +78,13 @@ class MoodleInternalSniff implements Sniff {
         }
 
         // Find where real code is and check from there.
-        $pointer = $this->get_position_of_relevant_code($file, $pointer);
+        $pointer = $this->getPositionOfRelevantCode($file, $pointer);
         if (!$pointer) {
             // The file only contains non-relevant (and non side-effects) code. We are done.
             return;
         }
 
-        if ($this->is_config_php_incluson($file, $pointer)) {
+        if ($this->isConfigPhpInclusion($file, $pointer)) {
             // We are requiring config.php. This file is good, hurrah!
             return;
         }
@@ -95,46 +94,60 @@ class MoodleInternalSniff implements Sniff {
         $sideEffectsPointer = $pointer;
 
         // OK, we've got to the first bit of relevant code. It must be the MOODLE_INTERNAL check.
-        if ($this->is_moodle_internal_or_die_check($file, $pointer)) {
+        if ($this->isMoodleInternalOrDieCheck($file, $pointer)) {
             $hasMoodleInternal = true;
             // Let's look for side effects after the check.
             $sideEffectsPointer = $file->findNext(T_SEMICOLON, $pointer) + 1;
-
-        } else if ($this->is_if_not_moodle_internal_die_check($file, $pointer)) {
+        } elseif ($this->isIfNotMoodleInternalDieCheck($file, $pointer)) {
             $hasMoodleInternal = true;
             $isOldMoodleInternal = true;
             // Let's look for side effects after the check.
             $sideEffectsPointer = $file->getTokens()[$pointer]['scope_closer'] + 1;
         }
 
-        $hasSideEffects = $this->code_changes_global_state($file, $sideEffectsPointer, ($file->numTokens - 1));
-        $hasMultipleArtifacts = ($this->count_artifacts($file) > 1);
+        $hasSideEffects = $this->codeChangesGlobalState($file, $sideEffectsPointer, ($file->numTokens - 1));
+        $hasMultipleArtifacts = ($this->countArtifacts($file) > 1);
 
         // Missing MOODLE_INTERNAL and having side effects, error.
         if (!$hasMoodleInternal && $hasSideEffects) {
-            $file->addError('Expected MOODLE_INTERNAL check or config.php inclusion. Change in global state detected.',
-                $pointer, 'MoodleInternalGlobalState');
+            $file->addError(
+                'Expected MOODLE_INTERNAL check or config.php inclusion. Change in global state detected.',
+                $pointer,
+                'MoodleInternalGlobalState'
+            );
             return;
         }
 
         // Missing MOODLE_INTERNAL, not having side effects, but having multiple artifacts, warning.
         if (!$hasMoodleInternal && !$hasSideEffects && $hasMultipleArtifacts) {
-            $file->addWarning('Expected MOODLE_INTERNAL check or config.php inclusion. Multiple artifacts detected.',
-                $pointer, 'MoodleInternalMultipleArtifacts');
+            $file->addWarning(
+                'Expected MOODLE_INTERNAL check or config.php inclusion. Multiple artifacts detected.',
+                $pointer,
+                'MoodleInternalMultipleArtifacts'
+            );
             return;
         }
 
         // Having MOODLE_INTERNAL, not having side effects and not having multiple artifacts, error.
-        if ($hasMoodleInternal && !$hasSideEffects && !$hasMultipleArtifacts) {
-            $file->addWarning('Unexpected MOODLE_INTERNAL check. No side effects or multiple artifacts detected.',
-                $pointer, 'MoodleInternalNotNeeded');
+        if (
+            $hasMoodleInternal &&
+            !$hasSideEffects && !$hasMultipleArtifacts
+        ) {
+            $file->addWarning(
+                'Unexpected MOODLE_INTERNAL check. No side effects or multiple artifacts detected.',
+                $pointer,
+                'MoodleInternalNotNeeded'
+            );
             return;
         }
 
         // Having old MOODLE_INTERNAL check, warn.
         if ($hasMoodleInternal && $isOldMoodleInternal) {
-            $file->addWarning('Old MOODLE_INTERNAL check detected. Replace it by "defined(\'MOODLE_INTERNAL\') || die();"',
-                $pointer, 'MoodleInternalOld');
+            $file->addWarning(
+                'Old MOODLE_INTERNAL check detected. Replace it by "defined(\'MOODLE_INTERNAL\') || die();"',
+                $pointer,
+                'MoodleInternalOld'
+            );
             return;
         }
     }
@@ -147,7 +160,7 @@ class MoodleInternalSniff implements Sniff {
      * @param int $pointer The position in the stack.
      * @return int position in stack of relevant code.
      */
-    protected function get_position_of_relevant_code(File $file, $pointer) {
+    protected function getPositionOfRelevantCode(File $file, $pointer) {
         // Advance through tokens until we find some real code.
         $tokens = $file->getTokens();
         $relevantcodefound = false;
@@ -159,14 +172,14 @@ class MoodleInternalSniff implements Sniff {
             if ($tokens[$pointer]['code'] === T_NAMESPACE || $tokens[$pointer]['code'] === T_USE) {
                 // Namespace definitions are allowed before anything else, jump to end of namspace statement.
                 $pointer = $file->findEndOfStatement($pointer + 1, T_COMMA);
-            } else if ($tokens[$pointer]['code'] === T_STRING && $tokens[$pointer]['content'] == 'define') {
+            } elseif ($tokens[$pointer]['code'] === T_STRING && $tokens[$pointer]['content'] == 'define') {
                 // Some things like AJAX_SCRIPT NO_MOODLE_COOKIES need to be defined before config inclusion.
                 // Jump to end of define().
                 $pointer = $file->findEndOfStatement($pointer + 1);
-            } else if ($tokens[$pointer]['code'] === T_DECLARE && $tokens[$pointer]['content'] == 'declare') {
+            } elseif ($tokens[$pointer]['code'] === T_DECLARE && $tokens[$pointer]['content'] == 'declare') {
                 // Declare statements must be at start of file.
                 $pointer = $file->findEndOfStatement($pointer + 1);
-            } else if ($tokens[$pointer]['code'] === T_ATTRIBUTE) {
+            } elseif ($tokens[$pointer]['code'] === T_ATTRIBUTE) {
                 // Attribute statements may exist before code. Skip them.
                 $pointer = $tokens[$pointer]['attribute_closer'] + 1;
             } else {
@@ -186,23 +199,25 @@ class MoodleInternalSniff implements Sniff {
      * @param int $pointer The position in the stack.
      * @return bool true if is a moodle internal statement
      */
-    protected function is_moodle_internal_or_die_check(File $file, $pointer) {
+    protected function isMoodleInternalOrDieCheck(File $file, $pointer) {
         $tokens = $file->getTokens();
-        if ($tokens[$pointer]['code'] !== T_STRING or $tokens[$pointer]['content'] !== 'defined') {
+        if ($tokens[$pointer]['code'] !== T_STRING || $tokens[$pointer]['content'] !== 'defined') {
             return false;
         }
 
         $ignoredtokens = array_merge(Tokens::$emptyTokens, Tokens::$bracketTokens);
 
         $pointer = $file->findNext($ignoredtokens, $pointer + 1, null, true);
-        if ($tokens[$pointer]['code'] !== T_CONSTANT_ENCAPSED_STRING or
-            $tokens[$pointer]['content'] !== "'MOODLE_INTERNAL'") {
+        if (
+            $tokens[$pointer]['code'] !== T_CONSTANT_ENCAPSED_STRING ||
+            $tokens[$pointer]['content'] !== "'MOODLE_INTERNAL'"
+        ) {
             return false;
         }
 
         $pointer = $file->findNext($ignoredtokens, $pointer + 1, null, true);
 
-        if ($tokens[$pointer]['code'] !== T_BOOLEAN_OR and $tokens[$pointer]['code'] !== T_LOGICAL_OR) {
+        if ($tokens[$pointer]['code'] !== T_BOOLEAN_OR && $tokens[$pointer]['code'] !== T_LOGICAL_OR) {
             return false;
         }
 
@@ -221,10 +236,13 @@ class MoodleInternalSniff implements Sniff {
      * @param int $pointer The position in the stack.
      * @return bool true if is a config.php inclusion.
      */
-    protected function is_config_php_incluson(File $file, $pointer) {
+    protected function isConfigPhpInclusion(File $file, $pointer) {
         $tokens = $file->getTokens();
 
-        if ($tokens[$pointer]['code'] !== T_REQUIRE and $tokens[$pointer]['code'] !== T_REQUIRE_ONCE) {
+        if (
+            $tokens[$pointer]['code'] !== T_REQUIRE &&
+            $tokens[$pointer]['code'] !== T_REQUIRE_ONCE
+        ) {
             return false;
         }
 
@@ -248,11 +266,11 @@ class MoodleInternalSniff implements Sniff {
      * @param int $pointer The position in the stack.
      * @return bool true if is a moodle internal statement
      */
-    protected function is_if_not_moodle_internal_die_check(File $file, $pointer) {
+    protected function isIfNotMoodleInternalDieCheck(File $file, $pointer) {
         $tokens = $file->getTokens();
 
         // Detect 'if'.
-        if ($tokens[$pointer]['code'] !== T_IF ) {
+        if ($tokens[$pointer]['code'] !== T_IF) {
             return false;
         }
 
@@ -266,14 +284,16 @@ class MoodleInternalSniff implements Sniff {
 
         // Detect 'defined'.
         $pointer = $file->findNext($ignoredtokens, $pointer + 1, null, true);
-        if ($tokens[$pointer]['code'] !== T_STRING or $tokens[$pointer]['content'] !== 'defined') {
+        if ($tokens[$pointer]['code'] !== T_STRING || $tokens[$pointer]['content'] !== 'defined') {
             return false;
         }
 
         // Detect 'MOODLE_INTERNAL'.
         $pointer = $file->findNext($ignoredtokens, $pointer + 1, null, true);
-        if ($tokens[$pointer]['code'] !== T_CONSTANT_ENCAPSED_STRING or
-            $tokens[$pointer]['content'] !== "'MOODLE_INTERNAL'") {
+        if (
+            $tokens[$pointer]['code'] !== T_CONSTANT_ENCAPSED_STRING ||
+            $tokens[$pointer]['content'] !== "'MOODLE_INTERNAL'"
+        ) {
             return false;
         }
 
@@ -293,14 +313,13 @@ class MoodleInternalSniff implements Sniff {
      *
      * @return int the number of classes, interfaces and traits in the file.
      */
-    private function count_artifacts(File $file) {
+    private function countArtifacts(File $file) {
         $position = 0;
         $counter = 0;
         while ($position !== false) {
             if ($position = $file->findNext([T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM], ($position + 1))) {
                 $counter++;
             }
-
         }
         return $counter;
     }
@@ -314,10 +333,9 @@ class MoodleInternalSniff implements Sniff {
      * @param File $file The file being scanned.
      * @param int $start The token to start searching from.
      * @param int $end The token to search to.
-     * @param array $tokens The stack of tokens that make up the file.
-     * @return true if side effect is detected in the code.
+     * @return bool true if side effect is detected in the code.
      */
-    private function code_changes_global_state(File $file, $start, $end) {
+    private function codeChangesGlobalState(File $file, $start, $end) {
         $tokens = $file->getTokens();
         $symbols = [
             T_CLASS => T_CLASS,
@@ -382,10 +400,9 @@ class MoodleInternalSniff implements Sniff {
             if (isset($symbols[$tokens[$i]['code']]) === true && isset($tokens[$i]['scope_closer']) === true) {
                 $i = $tokens[$i]['scope_closer'];
                 continue;
-            } else if ($tokens[$i]['code'] === T_STRING && strtolower($tokens[$i]['content']) === 'define') {
+            } elseif ($tokens[$i]['code'] === T_STRING && strtolower($tokens[$i]['content']) === 'define') {
                 $prev = $file->findPrevious(T_WHITESPACE, ($i - 1), null, true);
                 if ($tokens[$prev]['code'] !== T_OBJECT_OPERATOR) {
-
                     $semicolon = $file->findNext(T_SEMICOLON, ($i + 1));
                     if ($semicolon !== false) {
                         $i = $semicolon;
@@ -404,7 +421,7 @@ class MoodleInternalSniff implements Sniff {
                     continue;
                 }
 
-                if ($this->code_changes_global_state($file, ($tokens[$i]['scope_opener'] + 1), ($tokens[$i]['scope_closer'] - 1))) {
+                if ($this->codeChangesGlobalState($file, ($tokens[$i]['scope_opener'] + 1), ($tokens[$i]['scope_closer'] - 1))) {
                     return true;
                 }
 

--- a/moodle/Sniffs/Files/RequireLoginSniff.php
+++ b/moodle/Sniffs/Files/RequireLoginSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,14 +13,13 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Checks that each file contains necessary login checks.
  *
- * @package    local_codechecker
  * @copyright  2016 Dan Poltawski <dan@moodle.com>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\Files;
@@ -27,14 +27,15 @@ namespace MoodleHQ\MoodleCS\moodle\Sniffs\Files;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class RequireLoginSniff implements Sniff {
+class RequireLoginSniff implements Sniff
+{
     public $loginfunctions = ['require_login', 'require_course_login', 'require_admin', 'admin_externalpage_setup'];
     public $ignorewhendefined = ['NO_MOODLE_COOKIES', 'CLI_SCRIPT', 'ABORT_AFTER_CONFIG'];
     /**
      * Register for open tag (only process once per file).
      */
     public function register() {
-        return array(T_OPEN_TAG);
+        return [T_OPEN_TAG];
     }
 
     /**
@@ -50,22 +51,25 @@ class RequireLoginSniff implements Sniff {
             return; // @codeCoverageIgnore
         }
 
-        $pointer = $this->get_config_inclusion_position($file, $pointer);
+        $pointer = $this->getConfigInclusionPosition($file, $pointer);
         if ($pointer === false) {
             // Config.php not included form file.
             return;
         }
 
         // OK, we've got a config.php.
-        if ($this->should_skip_login_checks($file, $pointer)) {
+        if ($this->shouldSkipLoginChecks($file, $pointer)) {
             // Login function check not necessary.
             return;
         }
 
-        if (!$this->is_login_function_present($file, $pointer)) {
+        if (!$this->isLoginFunctionPresent($file, $pointer)) {
             $loginfunctionsstr = implode(', ', $this->loginfunctions);
-            $file->addWarning("Expected login check ($loginfunctionsstr) following config inclusion. None found.",
-                $pointer, 'Missing');
+            $file->addWarning(
+                "Expected login check ($loginfunctionsstr) following config inclusion. None found.",
+                $pointer,
+                'Missing'
+            );
         }
     }
 
@@ -76,7 +80,7 @@ class RequireLoginSniff implements Sniff {
      * @param int $pointer The position in the stack.
      * @return int|false the position in the file or false if no require statement found.
      */
-    protected function get_config_inclusion_position(File $file, $pointer) {
+    protected function getConfigInclusionPosition(File $file, $pointer) {
         for ($i = $pointer; $i < $file->numTokens; $i++) {
             $i = $file->findNext([T_REQUIRE, T_REQUIRE_ONCE], $i);
             if ($i === false) {
@@ -84,7 +88,7 @@ class RequireLoginSniff implements Sniff {
                 return false;
             }
 
-            if ($this->is_a_config_php_incluson($file, $i)) {
+            if ($this->isConfigPhpInclusion($file, $i)) {
                 // Found config.php.
                 return $i;
             }
@@ -99,7 +103,7 @@ class RequireLoginSniff implements Sniff {
      * @param int $pointer The position in the stack.
      * @return bool true if it is a config inclusion
      */
-    protected function is_a_config_php_incluson(File $file, $pointer) {
+    protected function isConfigPhpInclusion(File $file, $pointer) {
         $tokens = $file->getTokens();
 
         // It's a require() or require_once() statement. Is it require(config.php)?
@@ -119,11 +123,10 @@ class RequireLoginSniff implements Sniff {
      * @param int $pointer The position in the stack.
      * @return bool true if the checks should be skipped
      */
-    protected function should_skip_login_checks(File $file, $pointer) {
+    protected function shouldSkipLoginChecks(File $file, $pointer) {
         $tokens = $file->getTokens();
 
         for ($i = $pointer; $i > 0; $i--) {
-
             $i = $file->findPrevious(T_STRING, $i);
             if ($i === false) {
                 // We've got to the start. A login function must be necessary.
@@ -154,7 +157,7 @@ class RequireLoginSniff implements Sniff {
      * @param int $pointer The position in the stack.
      * @return bool true if the current point in stack is a login function.
      */
-    protected function is_a_login_function(File $file, $pointer) {
+    protected function isLginFunction(File $file, $pointer) {
         $tokens = $file->getTokens();
 
         if (in_array($tokens[$pointer]['content'], $this->loginfunctions)) {
@@ -171,14 +174,14 @@ class RequireLoginSniff implements Sniff {
      * @param int $pointer The position in the stack.
      * @return true if login function is present.
      */
-    protected function is_login_function_present(File $file, $pointer) {
+    protected function isLoginFunctionPresent(File $file, $pointer) {
         for ($i = $pointer; $i < $file->numTokens; $i++) {
             $i = $file->findNext(T_STRING, $i);
             if ($i === false) {
                 return false;
             }
 
-            if ($this->is_a_login_function($file, $i)) {
+            if ($this->isLginFunction($file, $i)) {
                 return true;
             }
 
@@ -188,6 +191,5 @@ class RequireLoginSniff implements Sniff {
                 return false;
             }
         }
-
     }
 }

--- a/moodle/Sniffs/Namespaces/NamespaceStatementSniff.php
+++ b/moodle/Sniffs/Namespaces/NamespaceStatementSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,14 +13,13 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Checks that each file contains the standard GPL comment.
  *
- * @package    moodle-cs
  * @copyright  2023 Andrew Lyons <andrew@nicols.co.uk>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\Namespaces;
@@ -28,9 +28,8 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
-// phpcs:disable moodle.NamingConventions
-
-class NamespaceStatementSniff implements Sniff {
+class NamespaceStatementSniff implements Sniff
+{
     public function register()
     {
         return [

--- a/moodle/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/moodle/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,7 +13,7 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * moodle_sniffs_namingconventions_validfunctionnamesniff.
@@ -20,23 +21,20 @@
  * Ensures method names are correct depending on whether they are public
  * or private, and that functions are named correctly.
  *
- * @package    local_codechecker
  * @copyright  2009 Nicolas Connault
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\NamingConventions;
-
-// phpcs:disable moodle.NamingConventions
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
 use PHP_CodeSniffer\Util\Tokens;
 
-class ValidFunctionNameSniff extends AbstractScopeSniff {
-
+class ValidFunctionNameSniff extends AbstractScopeSniff
+{
     /** @var array A list of all PHP magic methods. */
-    private $magicmethods = array(
+    private $magicmethods = [
         'construct',
         'destruct',
         'call',
@@ -54,14 +52,14 @@ class ValidFunctionNameSniff extends AbstractScopeSniff {
         'set_state',
         'clone',
         'debuginfo',
-    );
+    ];
 
     /** @var array A list of all PHP magic functions. */
-    private $magicfunctions = array(
-        'autoload'
-    );
+    private $magicfunctions = [
+        'autoload',
+    ];
 
-    private $permittedmethods = array(
+    private $permittedmethods = [
         'setUp',
         'tearDown', // Used by simpletest.
         'setUpBeforeClass',
@@ -71,13 +69,13 @@ class ValidFunctionNameSniff extends AbstractScopeSniff {
         'offsetUnset', // Defined by the PHP ArrayAccess interface.
         'tearDownAfterClass',
         'jsonSerialize',
-    );
+    ];
 
     /**
      * Constructs a moodle_sniffs_namingconventions_validfunctionnamesniff.
      */
     public function __construct() {
-        parent::__construct(Tokens::$ooScopeTokens, array(T_FUNCTION), true);
+        parent::__construct(Tokens::$ooScopeTokens, [T_FUNCTION], true);
     }
 
     /**
@@ -89,8 +87,7 @@ class ValidFunctionNameSniff extends AbstractScopeSniff {
      *
      * @return void
      */
-    protected function processTokenWithinScope(File $phpcsfile,
-            $stackptr, $currscope) {
+    protected function processTokenWithinScope(File $phpcsfile, $stackptr, $currscope) {
         $classname  = $phpcsfile->getDeclarationName($currscope);
         $methodname = $phpcsfile->getDeclarationName($stackptr);
 
@@ -112,12 +109,13 @@ class ValidFunctionNameSniff extends AbstractScopeSniff {
         $scopespecified = $methodprops['scope_specified'];
 
         // Only lower-case accepted.
-        if (preg_match('/[A-Z]+/', $methodname) &&
-                !in_array($methodname, $this->permittedmethods)) {
-
+        if (
+            preg_match('/[A-Z]+/', $methodname) &&
+            !in_array($methodname, $this->permittedmethods)
+        ) {
             if ($scopespecified === true) {
                 $error = ucfirst($scope) . ' method name "' . $classname . '::' .
-                        $methodname .'" must be in lower-case letters only';
+                    $methodname . '" must be in lower-case letters only';
             } else {
                 $error = 'method name "' . $classname . '::' . $methodname .
                         '" must be in lower-case letters only';

--- a/moodle/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/moodle/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,31 +13,28 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Checks variable names are all lower-case, no underscores.
  *
- * @package    local_codechecker
  * @copyright  2009 Nicolas Connault
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\NamingConventions;
 
-// phpcs:disable moodle.NamingConventions
-
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
 use PHP_CodeSniffer\Files\File;
 
-class ValidVariableNameSniff extends AbstractVariableSniff {
-
-    static public $allowedglobals = array('ADMIN', 'CFG', 'COURSE', 'DB', 'FULLME',
-            'OUTPUT', 'PAGE', 'PERF', 'SESSION', 'SITE', 'THEME', 'USER',
-            '_SERVER', '_GET', '_POST', '_FILES', '_REQUEST', '_SESSION', '_ENV',
-            '_COOKIE', '_HTTP_RAW_POST_DATA', 'ACCESSLIB_PRIVATE', 'ME',
-            'CONDITIONLIB_PRIVATE', 'FILTERLIB_PRIVATE', 'SCRIPT', 'MNET_REMOTE_CLIENT',
-            'http_response_header');
+class ValidVariableNameSniff extends AbstractVariableSniff
+{
+    public static $allowedglobals = ['ADMIN', 'CFG', 'COURSE', 'DB', 'FULLME',
+        'OUTPUT', 'PAGE', 'PERF', 'SESSION', 'SITE', 'THEME', 'USER',
+        '_SERVER', '_GET', '_POST', '_FILES', '_REQUEST', '_SESSION', '_ENV',
+        '_COOKIE', '_HTTP_RAW_POST_DATA', 'ACCESSLIB_PRIVATE', 'ME',
+        'CONDITIONLIB_PRIVATE', 'FILTERLIB_PRIVATE', 'SCRIPT', 'MNET_REMOTE_CLIENT',
+        'http_response_header'];
 
     /**
      * Processes class member variables.
@@ -93,7 +91,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff {
     protected function processVariable(File $phpcsfile, $stackptr) {
         $tokens = $phpcsfile->getTokens();
         $membername     = ltrim($tokens[$stackptr]['content'], '$');
-        $this->validate_moodle_variable_name($membername, $phpcsfile, $stackptr);
+        $this->validateMoodleVariableName($membername, $phpcsfile, $stackptr);
     }
 
     /**
@@ -107,12 +105,17 @@ class ValidVariableNameSniff extends AbstractVariableSniff {
     protected function processVariableInString(File $phpcsfile, $stackptr) {
         $tokens = $phpcsfile->getTokens();
 
-        if (preg_match_all('/[^\\\\]\$([A-Za-z0-9_]+)(\-\>([A-Za-z0-9_]+))?/i',
-                $tokens[$stackptr]['content'], $matches)) {
+        if (
+            preg_match_all(
+                '/[^\\\\]\$([A-Za-z0-9_]+)(\-\>([A-Za-z0-9_]+))?/i',
+                $tokens[$stackptr]['content'],
+                $matches
+            )
+        ) {
             $captured = $matches[1];
 
             foreach ($captured as $varname) {
-                $this->validate_moodle_variable_name($varname, $phpcsfile, $stackptr);
+                $this->validateMoodleVariableName($varname, $phpcsfile, $stackptr);
             }
         }
     }
@@ -127,7 +130,7 @@ class ValidVariableNameSniff extends AbstractVariableSniff {
      *
      * @return void
      */
-    private function validate_moodle_variable_name($varname, File $phpcsfile, $stackptr) {
+    private function validateMoodleVariableName($varname, File $phpcsfile, $stackptr) {
         if (preg_match('/[A-Z]+/', $varname) && !in_array($varname, self::$allowedglobals)) {
             $error = "Variable \"$varname\" must be all lower-case";
             $fix = $phpcsfile->addFixableError($error, $stackptr, 'VariableNameLowerCase');
@@ -135,7 +138,9 @@ class ValidVariableNameSniff extends AbstractVariableSniff {
                 $phpcsfile->fixer->beginChangeset();
                 $tokens = $phpcsfile->getTokens();
                 $phpcsfile->fixer->replaceToken(
-                    $stackptr, str_replace('$' . $varname, '$' . strtolower($varname), $tokens[$stackptr]['content']));
+                    $stackptr,
+                    str_replace('$' . $varname, '$' . strtolower($varname), $tokens[$stackptr]['content'])
+                );
                 $phpcsfile->fixer->endChangeset();
             }
         }

--- a/moodle/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/moodle/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,11 +13,9 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHP;
-
-// phpcs:disable moodle.NamingConventions
 
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DeprecatedFunctionsSniff as GenericDeprecatedFunctionsSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
@@ -42,12 +41,11 @@ use PHP_CodeSniffer\Files\File;
  * (because unit tests DO NOT parse the ruleset.xml details, like
  * properties, excludes... and other info).
  *
- * @package    local_codechecker
  * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
  * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class DeprecatedFunctionsSniff extends GenericDeprecatedFunctionsSniff {
-
+class DeprecatedFunctionsSniff extends GenericDeprecatedFunctionsSniff
+{
     /**
      * If true, an error will be thrown; otherwise a warning.
      *
@@ -84,7 +82,7 @@ class DeprecatedFunctionsSniff extends GenericDeprecatedFunctionsSniff {
      * @todo: This method can be removed once/if this PR accepted:
      *        https://github.com/squizlabs/PHP_CodeSniffer/pull/3295
      */
-    protected function addError($phpcsFile, $stackPtr, $function, $pattern=null) {
+    protected function addError($phpcsFile, $stackPtr, $function, $pattern = null) {
         $data  = [$function];
         $error = 'Function %s() has been deprecated';
         $type  = 'Deprecated';
@@ -93,8 +91,9 @@ class DeprecatedFunctionsSniff extends GenericDeprecatedFunctionsSniff {
             $pattern = strtolower($function);
         }
 
-        if ($this->forbiddenFunctions[$pattern] !== null
-            && $this->forbiddenFunctions[$pattern] !== 'null'
+        if (
+            $this->forbiddenFunctions[$pattern] !== null &&
+            $this->forbiddenFunctions[$pattern] !== 'null'
         ) {
             $type  .= 'WithAlternative';
             $data[] = $this->forbiddenFunctions[$pattern];
@@ -106,6 +105,5 @@ class DeprecatedFunctionsSniff extends GenericDeprecatedFunctionsSniff {
         } else {
             $phpcsFile->addWarning($error, $stackPtr, $type, $data);
         }
-
-    }//end addError()
+    }
 }

--- a/moodle/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/moodle/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,11 +13,9 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHP;
-
-// phpcs:disable moodle.NamingConventions
 
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff as GenericForbiddenFunctionsSniff;
 use PHP_CodeSniffer\Sniffs\Sniff;
@@ -42,12 +41,11 @@ use PHP_CodeSniffer\Files\File;
  * (because unit tests DO NOT parse the ruleset.xml details, like
  * properties, excludes... and other info).
  *
- * @package    local_codechecker
  * @copyright  2011 The Open University
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class ForbiddenFunctionsSniff extends GenericForbiddenFunctionsSniff {
-
+class ForbiddenFunctionsSniff extends GenericForbiddenFunctionsSniff
+{
     /**
      * A list of forbidden functions with their alternatives.
      *

--- a/moodle/Sniffs/PHP/ForbiddenGlobalUseSniff.php
+++ b/moodle/Sniffs/PHP/ForbiddenGlobalUseSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,25 +13,22 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Sniff to detect people using global $PAGE and $OUTPUT in renderers, or global $PAGE in blocks.
  *
- * @package    local_codechecker
  * @copyright  2020 The Open University
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHP;
 
-// phpcs:disable moodle.NamingConventions
-
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
 use PHP_CodeSniffer\Files\File;
 
-class ForbiddenGlobalUseSniff extends AbstractVariableSniff {
-
+class ForbiddenGlobalUseSniff extends AbstractVariableSniff
+{
     /**
      * @var array list of problems to detect. Each element is an array with three keys:
      *      classtype        - this is a human-readable description of this type of class, used in error messages.
@@ -67,7 +65,7 @@ class ForbiddenGlobalUseSniff extends AbstractVariableSniff {
         $tokens  = $phpcsFile->getTokens();
         $varName = ltrim($tokens[$stackPtr]['content'], '$');
 
-        $this->check_variable_usage($varName, $phpcsFile, $stackPtr);
+        $this->checkVariableUsage($varName, $phpcsFile, $stackPtr);
     }
 
     /**
@@ -78,7 +76,7 @@ class ForbiddenGlobalUseSniff extends AbstractVariableSniff {
 
         if (preg_match_all('|[^\\\]\$([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[$stackPtr]['content'], $matches) !== 0) {
             foreach ($matches[1] as $varName) {
-                $this->check_variable_usage($varName, $phpcsFile, $stackPtr);
+                $this->checkVariableUsage($varName, $phpcsFile, $stackPtr);
             }
         }
     }
@@ -90,9 +88,9 @@ class ForbiddenGlobalUseSniff extends AbstractVariableSniff {
      * @param File $phpcsFile The PHP_CodeSniffer file where this token was found.
      * @param int $stackPtr The position where the token was found.
      */
-    protected function check_variable_usage($varname, File $phpcsFile, $stackPtr) {
+    protected function checkVariableUsage($varname, File $phpcsFile, $stackPtr) {
         foreach ($this->forbiddencombinations as $forbiddencombination) {
-            $this->check_one_combination($varname, $forbiddencombination, $phpcsFile, $stackPtr);
+            $this->checkOneCombination($varname, $forbiddencombination, $phpcsFile, $stackPtr);
         }
     }
 
@@ -106,8 +104,12 @@ class ForbiddenGlobalUseSniff extends AbstractVariableSniff {
      * @param File $phpcsFile The PHP_CodeSniffer file where this token was found.
      * @param int $stackPtr  The position where the token was found.
      */
-    protected function check_one_combination($varname, $forbiddencombination,
-            File $phpcsFile, $stackPtr) {
+    protected function checkOneCombination(
+        $varname,
+        $forbiddencombination,
+        File $phpcsFile,
+        $stackPtr
+    ) {
         $tokens  = $phpcsFile->getTokens();
 
         if (!in_array($varname, $forbiddencombination['variables'])) {
@@ -127,9 +129,12 @@ class ForbiddenGlobalUseSniff extends AbstractVariableSniff {
 
             // If the classname matches, report the error.
             if (preg_match($forbiddencombination['classnamepattern'], $classname)) {
-                $phpcsFile->addError('global $' . $varname . ' cannot be used in ' .
-                        $forbiddencombination['classtype'] . '. Use $this->' . strtolower($varname) . '.',
-                        $stackPtr, 'BadGlobal');
+                $phpcsFile->addError(
+                    'global $' . $varname . ' cannot be used in ' .
+                    $forbiddencombination['classtype'] . '. Use $this->' . strtolower($varname) . '.',
+                    $stackPtr,
+                    'BadGlobal'
+                );
                 return;
             }
         }

--- a/moodle/Sniffs/PHP/ForbiddenTokensSniff.php
+++ b/moodle/Sniffs/PHP/ForbiddenTokensSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,7 +13,7 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * The use of some tokens is forbidden.
@@ -20,32 +21,29 @@
  * This Sniff looks for some functions and operators that are handled
  * as specific tokens by the CS tokenizer. Complements {@link moodle_Sniffs_PHP_ForbiddenFunctionsSniff}.
  *
- * @package    local_codechecker
- * @copyright  2014 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2014 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHP;
 
-// phpcs:disable moodle.NamingConventions
-
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class ForbiddenTokensSniff implements Sniff {
-
+class ForbiddenTokensSniff implements Sniff
+{
     /**
      * Returns an array of Tokenizer tokens and errors this Sniff will listen and process.
      *
      * @return array with tokens as keys and error messages as description.
      */
-    protected function get_forbidden_tokens() {
-        return array(
+    protected function getForbiddenTokens() {
+        return [
             T_EVAL => 'The use of function eval() is forbidden',
             T_GOTO => 'The use of operator goto is forbidden',
             T_GOTO_LABEL => 'The use of goto labels is forbidden',
             T_BACKTICK => 'The use of backticks for shell execution is forbidden',
-        );
+        ];
     }
 
     /**
@@ -54,7 +52,7 @@ class ForbiddenTokensSniff implements Sniff {
      * @return array tokens this sniff will handle.
      */
     public function register() {
-        return array_keys($this->get_forbidden_tokens());
+        return array_keys($this->getForbiddenTokens());
     }
 
     /**
@@ -68,7 +66,7 @@ class ForbiddenTokensSniff implements Sniff {
     public function process(File $phpcsFile, $stackPtr) {
 
         $tokens = $phpcsFile->getTokens();
-        $forbidden = $this->get_forbidden_tokens();
+        $forbidden = $this->getForbiddenTokens();
         $token = $tokens[$stackPtr];
         $phpcsFile->addError($forbidden[$token['code']], $stackPtr, 'Found');
     }

--- a/moodle/Sniffs/PHP/IncludingFileSniff.php
+++ b/moodle/Sniffs/PHP/IncludingFileSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,7 +13,7 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Checks that the include_once is used in conditional situations, and
@@ -22,22 +23,20 @@
  *
  * Based on {@link PEAR_Sniffs_Files_IncludingFileSniff}.
  *
- * @package    local_codechecker
  * @copyright  2011 The Open University
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHP;
-
-// phpcs:disable moodle.NamingConventions
 
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
-class IncludingFileSniff implements Sniff {
+class IncludingFileSniff implements Sniff
+{
     public function register() {
-        return array(T_INCLUDE_ONCE, T_REQUIRE_ONCE, T_REQUIRE, T_INCLUDE);
+        return [T_INCLUDE_ONCE, T_REQUIRE_ONCE, T_REQUIRE, T_INCLUDE];
     }
 
     public function process(File $file, $stackptr) {
@@ -45,7 +44,7 @@ class IncludingFileSniff implements Sniff {
 
         if ($tokens[$stackptr + 1]['code'] !== T_OPEN_PARENTHESIS) {
             $error = '"%s" must be immediately followed by an open parenthesis';
-            $data  = array($tokens[$stackptr]['content']);
+            $data  = [$tokens[$stackptr]['content']];
             $file->addError($error, $stackptr, 'BracketsRequired', $data);
         }
 
@@ -65,8 +64,7 @@ class IncludingFileSniff implements Sniff {
         // Check to see if they are assigning the return value of this
         // including call. If they are then they are probably checking it, so
         // it's conditional.
-        $previous = $file->findPrevious(Tokens::$emptyTokens,
-                ($stackptr - 1), null, true);
+        $previous = $file->findPrevious(Tokens::$emptyTokens, ($stackptr - 1), null, true);
         if (in_array($tokens[$previous]['code'], Tokens::$assignmentTokens)) {
             // The have assigned the return value to it, so its conditional.
             $incondition = true;
@@ -79,7 +77,7 @@ class IncludingFileSniff implements Sniff {
                 $error  = 'File is being unconditionally included; ';
                 $error .= 'use "require_once" instead';
                 $file->addError($error, $stackptr, 'UseRequireOnce');
-            } else if ($tokentype === T_INCLUDE) {
+            } elseif ($tokentype === T_INCLUDE) {
                 $error  = 'File is being unconditionally included; ';
                 $error .= 'use "require" instead';
                 $file->addError($error, $stackptr, 'UseRequire');

--- a/moodle/Sniffs/PHP/MemberVarScopeSniff.php
+++ b/moodle/Sniffs/PHP/MemberVarScopeSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,32 +13,28 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Verifies that class members have scope modifiers. Created by sam marshall,
  * based on a sniff by Greg Sherwood and Marc McIntyre.
  *
- * @package   local_codechecker
  * @author    Greg Sherwood <gsherwood@squiz.net>
  * @author    Marc McIntyre <mmcintyre@squiz.net>
  * @author    sam marshall <s.marshall@open.ac.uk>
  * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
  * @copyright 2011 The Open University
- * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @license   https://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHP;
-
-// phpcs:disable moodle.NamingConventions
 
 use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Util\Tokens;
 
-class MemberVarScopeSniff
-        extends AbstractVariableSniff {
-
+class MemberVarScopeSniff extends AbstractVariableSniff
+{
     /**
      * Processes the function tokens within the class.
      *
@@ -54,7 +51,7 @@ class MemberVarScopeSniff
 
         if ($modifier === false || $modifier < $semicolon) {
             $error = 'Scope modifier not specified for member variable "%s"';
-            $data  = array($tokens[$stackptr]['content']);
+            $data  = [$tokens[$stackptr]['content']];
             $file->addError($error, $stackptr, 'Missing', $data);
         }
     }

--- a/moodle/Sniffs/PHPUnit/TestCaseCoversSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseCoversSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,11 +13,9 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit;
-
-// phpcs:disable moodle.NamingConventions
 
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 use PHP_CodeSniffer\Sniffs\Sniff;
@@ -27,17 +26,16 @@ use PHPCSUtils\Utils\ObjectDeclarations;
 /**
  * Checks that a test file has the @coversxxx annotations properly defined.
  *
- * @package    local_codechecker
  * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class TestCaseCoversSniff implements Sniff {
-
+class TestCaseCoversSniff implements Sniff
+{
     /**
      * Register for open tag (only process once per file).
      */
     public function register() {
-        return array(T_OPEN_TAG);
+        return [T_OPEN_TAG];
     }
 
     /**
@@ -131,10 +129,18 @@ class TestCaseCoversSniff implements Sniff {
 
             // Both @covers and @coversNothing, that's a mistake. 2 errors.
             if ($classCovers && $classCoversNothing) {
-                $file->addError('Class %s has both @covers and @coversNothing tags, good contradiction',
-                    $classCovers, 'ContradictoryClass', [$class]);
-                $file->addError('Class %s has both @covers and @coversNothing tags, good contradiction',
-                    $classCoversNothing, 'ContradictoryClass', [$class]);
+                $file->addError(
+                    'Class %s has both @covers and @coversNothing tags, good contradiction',
+                    $classCovers,
+                    'ContradictoryClass',
+                    [$class]
+                );
+                $file->addError(
+                    'Class %s has both @covers and @coversNothing tags, good contradiction',
+                    $classCoversNothing,
+                    'ContradictoryClass',
+                    [$class]
+                );
             }
 
             // Iterate over all the methods in the class.
@@ -172,8 +178,12 @@ class TestCaseCoversSniff implements Sniff {
                                     break;
                                 case '@coversDefaultClass':
                                     // Not allowed in methods.
-                                    $file->addError('Method %s() has @coversDefaultClass tag, only allowed in classes',
-                                        $docPointer, 'DefaultClassNotAllowed', [$method]);
+                                    $file->addError(
+                                        'Method %s() has @coversDefaultClass tag, only allowed in classes',
+                                        $docPointer,
+                                        'DefaultClassNotAllowed',
+                                        [$method]
+                                    );
                                     break;
                             }
                         }
@@ -182,30 +192,54 @@ class TestCaseCoversSniff implements Sniff {
 
                 // No @covers or @coversNothing at any level, that's a missing one.
                 if (!$classCovers && !$classCoversNothing && !$methodCovers && !$methodCoversNothing) {
-                    $file->addWarning('Test method %s() is missing any coverage information, own or at class level',
-                        $mStart, 'Missing', [$method]);
+                    $file->addWarning(
+                        'Test method %s() is missing any coverage information, own or at class level',
+                        $mStart,
+                        'Missing',
+                        [$method]
+                    );
                 }
 
                 // Both @covers and @coversNothing, that's a mistake. 2 errors.
                 if ($methodCovers && $methodCoversNothing) {
-                    $file->addError('Method %s() has both @covers and @coversNothing tags, good contradiction',
-                        $methodCovers, 'ContradictoryMethod', [$method]);
-                    $file->addError('Method %s() has both @covers and @coversNothing tags, good contradiction',
-                        $methodCoversNothing, 'ContradictoryMethod', [$method]);
+                    $file->addError(
+                        'Method %s() has both @covers and @coversNothing tags, good contradiction',
+                        $methodCovers,
+                        'ContradictoryMethod',
+                        [$method]
+                    );
+                    $file->addError(
+                        'Method %s() has both @covers and @coversNothing tags, good contradiction',
+                        $methodCoversNothing,
+                        'ContradictoryMethod',
+                        [$method]
+                    );
                 }
 
                 // Found @coversNothing at class, and @covers at method, strange. Warning.
                 if ($classCoversNothing && $methodCovers) {
-                    $file->addWarning('Class %s has @coversNothing, but there are methods covering stuff',
-                        $classCoversNothing, 'ContradictoryMixed', [$class]);
-                    $file->addWarning('Test method %s() is covering stuff, but class has @coversNothing',
-                        $methodCovers, 'ContradictoryMixed', [$method]);
+                    $file->addWarning(
+                        'Class %s has @coversNothing, but there are methods covering stuff',
+                        $classCoversNothing,
+                        'ContradictoryMixed',
+                        [$class]
+                    );
+                    $file->addWarning(
+                        'Test method %s() is covering stuff, but class has @coversNothing',
+                        $methodCovers,
+                        'ContradictoryMixed',
+                        [$method]
+                    );
                 }
 
                 // Found @coversNothing at class and method, redundant. Warning.
                 if ($classCoversNothing && $methodCoversNothing) {
-                    $file->addWarning('Test method %s() has @coversNothing, but class also has it, redundant',
-                        $methodCoversNothing, 'Redundant', [$method]);
+                    $file->addWarning(
+                        'Test method %s() has @coversNothing, but class also has it, redundant',
+                        $methodCoversNothing,
+                        'Redundant',
+                        [$method]
+                    );
                 }
 
                 // Advance until the end of the method, if possible, to find the next one quicker.
@@ -228,19 +262,31 @@ class TestCaseCoversSniff implements Sniff {
 
         if ($tag === '@coversNothing') {
             // Check that there isn't whitespace and string.
-            if ($tokens[$pointer + 1]['code'] === T_DOC_COMMENT_WHITESPACE &&
-                    $tokens[$pointer + 2]['code'] === T_DOC_COMMENT_STRING) {
-                $file->addError('Wrong %s annotation, it must be empty',
-                    $pointer, 'NotEmpty', [$tag]);
+            if (
+                $tokens[$pointer + 1]['code'] === T_DOC_COMMENT_WHITESPACE &&
+                $tokens[$pointer + 2]['code'] === T_DOC_COMMENT_STRING
+            ) {
+                $file->addError(
+                    'Wrong %s annotation, it must be empty',
+                    $pointer,
+                    'NotEmpty',
+                    [$tag]
+                );
             }
         }
 
         if ($tag === '@covers' || $tag === '@coversDefaultClass') {
             // Check that there is whitespace and string.
-            if ($tokens[$pointer + 1]['code'] !== T_DOC_COMMENT_WHITESPACE ||
-                    $tokens[$pointer + 2]['code'] !== T_DOC_COMMENT_STRING) {
-                $file->addError('Wrong %s annotation, it must contain some value',
-                    $pointer, 'Empty', [$tag]);
+            if (
+                $tokens[$pointer + 1]['code'] !== T_DOC_COMMENT_WHITESPACE ||
+                $tokens[$pointer + 2]['code'] !== T_DOC_COMMENT_STRING
+            ) {
+                $file->addError(
+                    'Wrong %s annotation, it must contain some value',
+                    $pointer,
+                    'Empty',
+                    [$tag]
+                );
                 // No value, nothing else to check.
                 return;
             }
@@ -249,22 +295,36 @@ class TestCaseCoversSniff implements Sniff {
         if ($tag === '@coversDefaultClass') {
             // Check that value begins with \ (FQCN).
             if (strpos($tokens[$pointer + 2]['content'], '\\') !== 0) {
-                $file->addError('Wrong %s annotation, it must be FQCN (\\ prefixed)',
-                    $pointer, 'NoFQCN', [$tag]);
+                $file->addError(
+                    'Wrong %s annotation, it must be FQCN (\\ prefixed)',
+                    $pointer,
+                    'NoFQCN',
+                    [$tag]
+                );
             }
             // Check that value does not contain :: (method).
             if (strpos($tokens[$pointer + 2]['content'], '::') !== false) {
-                $file->addError('Wrong %s annotation, cannot point to a method (contains ::)',
-                    $pointer, 'WrongMethod', [$tag]);
+                $file->addError(
+                    'Wrong %s annotation, cannot point to a method (contains ::)',
+                    $pointer,
+                    'WrongMethod',
+                    [$tag]
+                );
             }
         }
 
         if ($tag === '@covers') {
             // Check value begins with \ (FQCN) or :: (method).
-            if (strpos($tokens[$pointer + 2]['content'], '\\') !== 0 &&
-                    strpos($tokens[$pointer + 2]['content'], '::') !== 0) {
-                $file->addError('Wrong %s annotation, it must be FQCN (\\ prefixed) or point to method (:: prefixed)',
-                    $pointer, 'NoFQCNOrMethod', [$tag]);
+            if (
+                strpos($tokens[$pointer + 2]['content'], '\\') !== 0 &&
+                strpos($tokens[$pointer + 2]['content'], '::') !== 0
+            ) {
+                $file->addError(
+                    'Wrong %s annotation, it must be FQCN (\\ prefixed) or point to method (:: prefixed)',
+                    $pointer,
+                    'NoFQCNOrMethod',
+                    [$tag]
+                );
             }
         }
     }

--- a/moodle/Sniffs/PHPUnit/TestCaseNamesSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseNamesSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,26 +13,23 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Checks that a test file has a class name matching the file name.
  *
- * @package    local_codechecker
  * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit;
-
-// phpcs:disable moodle.NamingConventions
 
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class TestCaseNamesSniff implements Sniff {
-
+class TestCaseNamesSniff implements Sniff
+{
     /**
      * List of classes that have been found during checking.
      *
@@ -50,7 +48,7 @@ class TestCaseNamesSniff implements Sniff {
      * Register for open tag (only process once per file).
      */
     public function register() {
-        return array(T_OPEN_TAG);
+        return [T_OPEN_TAG];
     }
 
     /**
@@ -153,15 +151,23 @@ class TestCaseNamesSniff implements Sniff {
 
         // Error if the found classname is "strange" (not "_test|_testcase" ended).
         if (substr($class, -5) !== '_test' && substr($class, -9) != '_testcase') {
-            $file->addError('PHPUnit irregular testcase name found: %s (_test/_testcase ended expected)', $cStart,
-                'Irregular', [$class]);
+            $file->addError(
+                'PHPUnit irregular testcase name found: %s (_test/_testcase ended expected)',
+                $cStart,
+                'Irregular',
+                [$class]
+            );
         }
 
         // Check if the file name and the class name match, warn if not.
         $baseName = pathinfo($fileName, PATHINFO_FILENAME);
         if ($baseName !== $class) {
-            $fix = $file->addFixableWarning('PHPUnit testcase name "%s" does not match file name "%s"', $cStart,
-                'NoMatch', [$class, $baseName]);
+            $fix = $file->addFixableWarning(
+                'PHPUnit testcase name "%s" does not match file name "%s"',
+                $cStart,
+                'NoMatch',
+                [$class, $baseName]
+            );
 
             if ($fix === true) {
                 if ($cNameToken = $file->findNext(T_STRING, $cStart + 1, $tokens[$cStart]['scope_opener'])) {
@@ -175,8 +181,12 @@ class TestCaseNamesSniff implements Sniff {
         if (isset($this->foundClasses[$fdqnClass])) {
             // Already found, this is a dupe class name, error!
             foreach ($this->foundClasses[$fdqnClass] as $exists) {
-                $file->addError('PHPUnit testcase "%s" already exists at "%s" line %s', $cStart,
-                    'DuplicateExists', [$fdqnClass, $exists['file'], $exists['line']]);
+                $file->addError(
+                    'PHPUnit testcase "%s" already exists at "%s" line %s',
+                    $cStart,
+                    'DuplicateExists',
+                    [$fdqnClass, $exists['file'], $exists['line']]
+                );
             }
         } else {
             // Create the empty element.
@@ -193,9 +203,13 @@ class TestCaseNamesSniff implements Sniff {
         if (isset($this->proposedClasses[$fdqnClass])) {
             // Already found, this is a dupe class name, error!
             foreach ($this->proposedClasses[$fdqnClass] as $exists) {
-                $file->addError('PHPUnit testcase "%s" already proposed for "%s" line %s. You ' .
-                    'may want to change the testcase name (file and class)', $cStart,
-                    'ProposedExists', [$fdqnClass, $exists['file'], $exists['line']]);
+                $file->addError(
+                    'PHPUnit testcase "%s" already proposed for "%s" line %s. You ' .
+                    'may want to change the testcase name (file and class)',
+                    $cStart,
+                    'ProposedExists',
+                    [$fdqnClass, $exists['file'], $exists['line']]
+                );
             }
         }
 
@@ -206,8 +220,12 @@ class TestCaseNamesSniff implements Sniff {
         if ($namespace && $moodleComponent) {
             // Verify that the namespace declared in the class matches the namespace expected for the file.
             if (strpos($namespace . '\\', $moodleComponent . '\\') !== 0) {
-                $file->addError('PHPUnit class namespace "%s" does not match expected file namespace "%s"', $nsStart,
-                    'UnexpectedNS', [$namespace, $moodleComponent]);
+                $file->addError(
+                    'PHPUnit class namespace "%s" does not match expected file namespace "%s"',
+                    $nsStart,
+                    'UnexpectedNS',
+                    [$namespace, $moodleComponent]
+                );
             }
 
             // Verify that level2 and down match the directory structure under tests. Soft warn if not (till we fix all).
@@ -221,30 +239,41 @@ class TestCaseNamesSniff implements Sniff {
 
                 // Warning if the relative namespace does not match the relative directory.
                 if ($reldir !== $relns) {
-                    $file->addWarning('PHPUnit class "%s", with namespace "%s", currently located at "tests/%s" directory, '.
-                        'does not match its expected location at "tests/%s"', $nsStart,
-                        'UnexpectedLevel2NS', [$fdqnClass, $namespace, $reldir, $relns]);
+                    $file->addWarning(
+                        'PHPUnit class "%s", with namespace "%s", currently located at "tests/%s" directory, ' .
+                        'does not match its expected location at "tests/%s"',
+                        $nsStart,
+                        'UnexpectedLevel2NS',
+                        [$fdqnClass, $namespace, $reldir, $relns]
+                    );
                 }
 
                 // TODO: When we have APIs (https://docs.moodle.org/dev/Core_APIs) somewhere at hand (in core)
                 // let's add here an error when incorrect ones are used. See MDL-71096 about it.
             }
-
         }
 
         if (!$namespace && $moodleComponent) {
-            $file->addWarning('PHPUnit class "%s" does not have any namespace. It is recommended to add it to the "%s" ' .
-                'namespace, using more levels if needed, in order to match the code being tested', $cStart,
-                'MissingNS', [$fdqnClass, $moodleComponent]);
+            $file->addWarning(
+                'PHPUnit class "%s" does not have any namespace. It is recommended to add it to the "%s" ' .
+                'namespace, using more levels if needed, in order to match the code being tested',
+                $cStart,
+                'MissingNS',
+                [$fdqnClass, $moodleComponent]
+            );
 
             // Check if the proposed class has been already proposed (this is useful when running against a lot of files).
             $fdqnProposed = $moodleComponent . '\\' . $fdqnClass;
             if (isset($this->proposedClasses[$fdqnProposed])) {
                 // Already found, this is a dupe class name, error!
                 foreach ($this->proposedClasses[$fdqnProposed] as $exists) {
-                    $file->addError('Proposed PHPUnit testcase "%s" already proposed for "%s" line %s. You ' .
-                        'may want to change the testcase name (file and class)', $cStart,
-                        'DuplicateProposed', [$fdqnProposed, $exists['file'], $exists['line']]);
+                    $file->addError(
+                        'Proposed PHPUnit testcase "%s" already proposed for "%s" line %s. You ' .
+                        'may want to change the testcase name (file and class)',
+                        $cStart,
+                        'DuplicateProposed',
+                        [$fdqnProposed, $exists['file'], $exists['line']]
+                    );
                 }
             } else {
                 // Create the empty element.
@@ -261,9 +290,13 @@ class TestCaseNamesSniff implements Sniff {
             if (isset($this->foundClasses[$fdqnProposed])) {
                 // Already found, this is a dupe class name, error!
                 foreach ($this->foundClasses[$fdqnProposed] as $exists) {
-                    $file->addError('Proposed PHPUnit testcase "%s" already exists at "%s" line %s. You ' .
-                        'may want to change the testcase name (file and class)', $cStart,
-                        'ExistsProposed', [$fdqnProposed, $exists['file'], $exists['line']]);
+                    $file->addError(
+                        'Proposed PHPUnit testcase "%s" already exists at "%s" line %s. You ' .
+                        'may want to change the testcase name (file and class)',
+                        $cStart,
+                        'ExistsProposed',
+                        [$fdqnProposed, $exists['file'], $exists['line']]
+                    );
                 }
             }
         }

--- a/moodle/Sniffs/PHPUnit/TestCaseProviderSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseProviderSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,11 +13,9 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit;
-
-// phpcs:disable moodle.NamingConventions
 
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 use PHP_CodeSniffer\Sniffs\Sniff;
@@ -27,12 +26,11 @@ use PHPCSUtils\Utils\FunctionDeclarations;
 /**
  * Checks that a test file has the @coversxxx annotations properly defined.
  *
- * @package    local_codechecker
  * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class TestCaseProviderSniff implements Sniff {
-
+class TestCaseProviderSniff implements Sniff
+{
     /**
      * Whether to autofix static providers.
      *
@@ -255,7 +253,7 @@ class TestCaseProviderSniff implements Sniff {
                 }
                 $file->fixer->endChangeset();
             }
-        } else if ($methodProps['scope'] !== 'public') {
+        } elseif ($methodProps['scope'] !== 'public') {
             $scopePointer = $file->findPrevious(Tokens::$scopeModifiers, $providerPointer - 1);
             $fix = $file->addFixableError(
                 'Data provider method "%s" must be public.',
@@ -357,8 +355,7 @@ class TestCaseProviderSniff implements Sniff {
         File $phpcsFile,
         int $classPtr,
         string $methodName
-    ): array
-    {
+    ): array {
         $data = [];
 
         $mStart = $classPtr;

--- a/moodle/Sniffs/PHPUnit/TestCasesAbstractSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCasesAbstractSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,11 +13,9 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit;
-
-// phpcs:disable moodle.NamingConventions
 
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 use PHP_CodeSniffer\Sniffs\Sniff;
@@ -27,9 +26,10 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * Checks that testcase classes are declared as abstract.
  *
  * @copyright  2024 Andrew Lyons <adrew@nicols.co.uk>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class TestCasesAbstractSniff implements Sniff {
+class TestCasesAbstractSniff implements Sniff
+{
     public function register() {
         return [
             T_OPEN_TAG,

--- a/moodle/Sniffs/PHPUnit/TestClassesFinalSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestClassesFinalSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,11 +13,9 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit;
-
-// phpcs:disable moodle.NamingConventions
 
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 use PHP_CodeSniffer\Sniffs\Sniff;
@@ -27,9 +26,10 @@ use PHPCSUtils\Utils\ObjectDeclarations;
  * Checks that test classes are declared as final.
  *
  * @copyright  2024 Andrew Lyons <adrew@nicols.co.uk>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class TestClassesFinalSniff implements Sniff {
+class TestClassesFinalSniff implements Sniff
+{
     public function register() {
         return [
             T_OPEN_TAG,
@@ -105,7 +105,7 @@ class TestClassesFinalSniff implements Sniff {
                         $file->fixer->endChangeset();
                     }
                 }
-            } else if (!$classInfo['is_final']) {
+            } elseif (!$classInfo['is_final']) {
                 $fix = $file->addFixableWarning(
                     'Unit test %s should be declared as final.',
                     $cStart,

--- a/moodle/Sniffs/PHPUnit/TestReturnTypeSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestReturnTypeSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,11 +13,9 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit;
-
-// phpcs:disable moodle.NamingConventions
 
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 use PHP_CodeSniffer\Sniffs\Sniff;
@@ -27,13 +26,11 @@ use PHPCSUtils\Utils\ObjectDeclarations;
 /**
  * Checks that a test file has the @coversxxx annotations properly defined.
  *
- * @package    local_codechecker
  * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class TestReturnTypeSniff implements Sniff
 {
-
     /**
      * Register for open tag (only process once per file).
      */
@@ -70,7 +67,8 @@ class TestReturnTypeSniff implements Sniff
         $tokens = $file->getTokens();
 
         // We only want to do this once per file.
-        $prevopentag = $file->findPrevious(T_OPEN_TAG,
+        $prevopentag = $file->findPrevious(
+            T_OPEN_TAG,
             $pointer - 1
         );
         if ($prevopentag !== false) {

--- a/moodle/Sniffs/Strings/ForbiddenStringsSniff.php
+++ b/moodle/Sniffs/Strings/ForbiddenStringsSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,25 +13,22 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Inspect some strings that may lead to incorrect uses of Moodle/PHP APIs.
  *
- * @package    local_codechecker
- * @copyright  2014 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2014 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\Strings;
 
-// phpcs:disable moodle.NamingConventions
-
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class ForbiddenStringsSniff implements Sniff {
-
+class ForbiddenStringsSniff implements Sniff
+{
     /**
      * Returns an array of tokens this test wants to listen for.
      *
@@ -38,7 +36,7 @@ class ForbiddenStringsSniff implements Sniff {
      */
     public function register() {
         // We are going to handle strings here.
-        return array(T_CONSTANT_ENCAPSED_STRING);
+        return [T_CONSTANT_ENCAPSED_STRING];
     }
 
     /**
@@ -51,9 +49,9 @@ class ForbiddenStringsSniff implements Sniff {
      */
     public function process(File $phpcsFile, $stackPtr) {
         // Delegate the processing to specialised methods.
-        $this->process_sql_as_keyword($phpcsFile, $stackPtr);
-        $this->process_regexp_separator_e($phpcsFile, $stackPtr);
-        $this->process_string_with_backticks($phpcsFile, $stackPtr);
+        $this->processSqlAsKeyword($phpcsFile, $stackPtr);
+        $this->processRegexpSeparatorE($phpcsFile, $stackPtr);
+        $this->processStringWithBackticks($phpcsFile, $stackPtr);
     }
 
     /**
@@ -64,7 +62,7 @@ class ForbiddenStringsSniff implements Sniff {
      *
      * @return void
      */
-    protected function process_sql_as_keyword(File $phpcsFile, $stackPtr) {
+    protected function processSqlAsKeyword(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();
         $token = $tokens[$stackPtr];
         $text = trim($token['content'], "'\"");
@@ -82,7 +80,7 @@ class ForbiddenStringsSniff implements Sniff {
      *
      * @return void
      */
-    protected function process_regexp_separator_e(File $phpcsFile, $stackPtr) {
+    protected function processRegexpSeparatorE(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();
         $token = $tokens[$stackPtr];
         $text = trim($token['content'], " '\"\t\n");
@@ -113,28 +111,21 @@ class ForbiddenStringsSniff implements Sniff {
      *
      * @return void
      */
-    protected function process_string_with_backticks(File $phpcsFile, $stackPtr) {
+    protected function processStringWithBackticks(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();
         $token = $tokens[$stackPtr];
         $text = trim($token['content'], "'\"");
         if (strpos($text, '`') !== false) { //phpcs:ignore moodle.Strings.ForbiddenStrings.Found
-
             // Exception. lang strings ending with _desc or _help can
             // contain backticks as they are correct Markdown formatting.
             // Look for previous string.
-            $prevString = $phpcsFile->findPrevious(
-                T_CONSTANT_ENCAPSED_STRING,
-                ($stackPtr - 1));
+            $prevString = $phpcsFile->findPrevious(T_CONSTANT_ENCAPSED_STRING, ($stackPtr - 1));
             if ($prevString) {
                 $prevtext = trim($tokens[$prevString]['content'], "'\"");
                 // Verify it matches _desc|_help.
                 if (preg_match('/(_desc|_help)$/', $prevtext)) {
                     // Verify it's an $string array element.
-                    $prevToken = $phpcsFile->findPrevious(
-                        T_OPEN_SQUARE_BRACKET,
-                        ($prevString - 1),
-                        null,
-                        true);
+                    $prevToken = $phpcsFile->findPrevious(T_OPEN_SQUARE_BRACKET, ($prevString - 1), null, true);
                     if ($prevToken) {
                         if ($tokens[$prevToken]['code'] === T_VARIABLE && $tokens[$prevToken]['content'] === '$string') {
                             // Confirmed we are in a valid lang string using Markdown, skip any warning.

--- a/moodle/Sniffs/WhiteSpace/SpaceAfterCommaSniff.php
+++ b/moodle/Sniffs/WhiteSpace/SpaceAfterCommaSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,14 +13,13 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Verify there is a single space after a comma.
  *
- * @package    local_codechecker
  * @copyright  2011 The Open University
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\WhiteSpace;
@@ -27,9 +27,10 @@ namespace MoodleHQ\MoodleCS\moodle\Sniffs\WhiteSpace;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class SpaceAfterCommaSniff implements Sniff {
+class SpaceAfterCommaSniff implements Sniff
+{
     public function register() {
-        return array(T_COMMA);
+        return [T_COMMA];
     }
 
     /**

--- a/moodle/Sniffs/WhiteSpace/WhiteSpaceInStringsSniff.php
+++ b/moodle/Sniffs/WhiteSpace/WhiteSpaceInStringsSniff.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,14 +13,13 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
  * Checks that each string does not have extra whitespace at end of line
  *
- * @package    local_codechecker
  * @copyright  2011 The Open University
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\WhiteSpace;
@@ -27,20 +27,20 @@ namespace MoodleHQ\MoodleCS\moodle\Sniffs\WhiteSpace;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
-class WhiteSpaceInStringsSniff implements Sniff {
-
+class WhiteSpaceInStringsSniff implements Sniff
+{
     /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
      */
     public function register() {
-        return array(
-        T_CONSTANT_ENCAPSED_STRING,
-        T_DOUBLE_QUOTED_STRING,
-        T_HEREDOC,
-        T_WHITESPACE
-        );
+        return [
+            T_CONSTANT_ENCAPSED_STRING,
+            T_DOUBLE_QUOTED_STRING,
+            T_HEREDOC,
+            T_WHITESPACE,
+        ];
     }
 
     /**

--- a/moodle/Tests/FilesBoilerPlateCommentTest.php
+++ b/moodle/Tests/FilesBoilerPlateCommentTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,25 +13,21 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test the BoilerplateCommentSniff sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\BoilerplateCommentSniff
  */
-class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase {
-
-    public function test_moodle_files_boilerplatecomment_ok() {
+class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase
+{
+    public function testMoodleFilesBoilerplateCommentOk() {
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.BoilerplateComment');
         $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/ok.php');
@@ -53,7 +50,7 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase {
         $this->verify_cs_results();
     }
 
-    public function test_moodle_files_boilerplatecomment_nophp() {
+    public function testMoodleFilesBoilerplateCommentNoPHP() {
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.BoilerplateComment');
         $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/nophp.php');
@@ -66,7 +63,7 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase {
         $this->verify_cs_results();
     }
 
-    public function test_moodle_files_boilerplatecomment_blank() {
+    public function testMoodleFilesBoilerplateCommentBlank() {
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.BoilerplateComment');
         $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/blank.php');
@@ -79,7 +76,7 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase {
         $this->verify_cs_results();
     }
 
-    public function test_moodle_files_boilerplatecomment_short() {
+    public function testMoodleFilesBoilerplateCommentShort() {
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.BoilerplateComment');
         $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/short.php');
@@ -92,7 +89,7 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase {
         $this->verify_cs_results();
     }
 
-    public function test_moodle_files_boilerplatecomment_short_empty() {
+    public function testMoodleFilesBoilerplateCommentShortEmpty() {
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.BoilerplateComment');
         $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/short_empty.php');
@@ -105,7 +102,7 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase {
         $this->verify_cs_results();
     }
 
-    public function test_moodle_files_boilerplatecomment_wrongline() {
+    public function testMoodleFilesBoilerplateCommentWrongLine() {
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.BoilerplateComment');
         $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/wrongline.php');
@@ -119,7 +116,7 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase {
         $this->verify_cs_results();
     }
 
-    public function test_moodle_files_boilerplatecomment_gnu_http() {
+    public function testMoodleFilesBoilerplateCommentGnuHttp() {
 
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.BoilerplateComment');
@@ -134,7 +131,7 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase {
     /**
      * Assert that www.gnu.org can be referred to via https URL in the boilerplate.
      */
-    public function test_moodle_files_boilerplatecomment_gnu_https() {
+    public function testMoodleFilesBoilerplateCommentGnuHttps() {
 
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.BoilerplateComment');

--- a/moodle/Tests/FilesBoilerPlateCommentTest.php
+++ b/moodle/Tests/FilesBoilerPlateCommentTest.php
@@ -28,104 +28,104 @@ namespace MoodleHQ\MoodleCS\moodle\Tests;
 class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase
 {
     public function testMoodleFilesBoilerplateCommentOk() {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.BoilerplateComment');
-        $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/ok.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/ok.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([]);
-        $this->set_warnings([]);
+        $this->setErrors([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
 
         // Also try with the <?php line having some // phpcs:xxxx annotations.
-        $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/ok2.php');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/ok2.php');
 
-        $this->set_errors([]);
-        $this->set_warnings([]);
+        $this->setErrors([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     public function testMoodleFilesBoilerplateCommentNoPHP() {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.BoilerplateComment');
-        $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/nophp.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/nophp.php');
 
-        $this->set_errors([
+        $this->setErrors([
             1 => 'moodle.Files.BoilerplateComment.NoPHP',
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     public function testMoodleFilesBoilerplateCommentBlank() {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.BoilerplateComment');
-        $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/blank.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/blank.php');
 
-        $this->set_errors([
+        $this->setErrors([
             2 => 'followed by exactly one newline',
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     public function testMoodleFilesBoilerplateCommentShort() {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.BoilerplateComment');
-        $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/short.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/short.php');
 
-        $this->set_errors([
+        $this->setErrors([
             14 => 'FileTooShort',
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     public function testMoodleFilesBoilerplateCommentShortEmpty() {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.BoilerplateComment');
-        $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/short_empty.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/short_empty.php');
 
-        $this->set_errors([
+        $this->setErrors([
             1 => 'FileTooShort',
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     public function testMoodleFilesBoilerplateCommentWrongLine() {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.BoilerplateComment');
-        $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/wrongline.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/wrongline.php');
 
-        $this->set_errors([
+        $this->setErrors([
             6 => 'version 3',
             11 => 'FITNESS',
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     public function testMoodleFilesBoilerplateCommentGnuHttp() {
 
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.BoilerplateComment');
-        $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/gnu_http.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/gnu_http.php');
 
-        $this->set_errors([]);
-        $this->set_warnings([]);
+        $this->setErrors([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -133,13 +133,13 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase
      */
     public function testMoodleFilesBoilerplateCommentGnuHttps() {
 
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.BoilerplateComment');
-        $this->set_fixture(__DIR__ . '/fixtures/files/boilerplatecomment/gnu_https.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/gnu_https.php');
 
-        $this->set_errors([]);
-        $this->set_warnings([]);
+        $this->setErrors([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/MoodleCSBaseTestCase.php
+++ b/moodle/Tests/MoodleCSBaseTestCase.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,7 +13,7 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
 
@@ -36,43 +37,41 @@ use PHP_CodeSniffer\Config;
  *
  * This file contains helper testcase for testing "moodle" CS Sniffs.
  *
- * @category   test
- * @package    MoodleHq\Moodle-Cs
- * @copyright  2013 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2013 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase {
-
+abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase
+{
     /**
-     * @var string name of the standard to be tested.
+     * @var string|null name of the standard to be tested.
      */
-    protected $standard = null;
+    protected ?string $standard = null;
 
     /**
-     * @var string code of the sniff to be tested. Must be part of the standard definition.
+     * @var string|null code of the sniff to be tested. Must be part of the standard definition.
      *             See {@see ::set_sniff()} for more information.
      */
-    protected $sniff = null;
+    protected ?string $sniff = null;
 
     /**
-     * @var string full path to the file used as input (fixture).
+     * @var string|null full path to the file used as input (fixture).
      */
-    protected $fixture = null;
+    protected ?string $fixture = null;
 
     /**
      * @var array custom config elements to setup before running phpcs. name => value.
      */
-    protected $customConfigs = [];
+    protected array $customConfigs = [];
 
     /**
-     * @var array error expectations to ve verified against execution results.
+     * @var array|null error expectations to ve verified against execution results.
      */
-    protected $errors = null;
+    protected ?array $errors = null;
 
     /**
-     * @var array warning expectations to ve verified against execution results.
+     * @var array|null warning expectations to ve verified against execution results.
      */
-    protected $warnings = null;
+    protected ?array $warnings = null;
 
     public function tearDown(): void {
         \MoodleHQ\MoodleCS\moodle\Util\MoodleUtil::setMockedComponentMappings([]);
@@ -143,7 +142,7 @@ abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase {
      */
     protected function set_fixture($fixture) {
         if (!is_readable($fixture)) {
-            $this->fail('Unreadable fixture passed: '. $fixture);
+            $this->fail('Unreadable fixture passed: ' . $fixture);
         }
         $this->fixture = $fixture;
     }
@@ -157,12 +156,12 @@ abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase {
         $this->errors = $errors;
         // Let's normalize numeric, empty and string errors.
         foreach ($this->errors as $line => $errordef) {
-            if (is_int($errordef) and $errordef > 0) {
+            if (is_int($errordef) && $errordef > 0) {
                 $this->errors[$line] = array_fill(0, $errordef, $errordef);
-            } else if (empty($errordef)) {
-                $this->errors[$line] = array();
-            } else if (is_string($errordef)) {
-                $this->errors[$line] = array($errordef);
+            } elseif (empty($errordef)) {
+                $this->errors[$line] = [];
+            } elseif (is_string($errordef)) {
+                $this->errors[$line] = [$errordef];
             }
         }
     }
@@ -190,12 +189,12 @@ abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase {
         $this->warnings = $warnings;
         // Let's normalize numeric, empty and string warnings.
         foreach ($this->warnings as $line => $warningdef) {
-            if (is_int($warningdef) and $warningdef > 0) {
+            if (is_int($warningdef) && $warningdef > 0) {
                 $this->warnings[$line] = array_fill(0, $warningdef, $warningdef);
-            } else if (empty($warningdef)) {
-                $this->warnings[$line] = array();
-            } else if (is_string($warningdef)) {
-                $this->warnings[$line] = array($warningdef);
+            } elseif (empty($warningdef)) {
+                $this->warnings[$line] = [];
+            } elseif (is_string($warningdef)) {
+                $this->warnings[$line] = [$warningdef];
             }
         }
     }
@@ -226,13 +225,13 @@ abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase {
     protected function verify_cs_results() {
         $config = new \PHP_CodeSniffer\Config();
         $config->cache     = false;
-        $config->standards = array($this->standard);
-        $config->sniffs    = array($this->sniff);
-        $config->ignored   = array();
+        $config->standards = [$this->standard];
+        $config->sniffs    = [$this->sniff];
+        $config->ignored   = [];
         $ruleset = new \PHP_CodeSniffer\Ruleset($config);
 
         // We don't accept undefined errors and warnings.
-        if (is_null($this->errors) and is_null($this->warnings)) {
+        if (is_null($this->errors) && is_null($this->warnings)) {
             $this->fail('Error and warning expectations undefined. You must define at least one.');
         }
 
@@ -240,8 +239,8 @@ abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase {
         try {
             $phpcsfile = new \PHP_CodeSniffer\Files\LocalFile($this->fixture, $ruleset, $config);
             $phpcsfile->process();
-        } catch (Exception $e) {
-            $this->fail('An unexpected exception has been caught: '. $e->getMessage());
+        } catch (\Exception $e) {
+            $this->fail('An unexpected exception has been caught: ' . $e->getMessage());
         }
 
         // Capture results.
@@ -326,21 +325,30 @@ abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase {
                 $info .= PHP_EOL . 'Actual: ' . json_encode($results[$line]);
             }
             // Verify counts for a line are the same.
-            $this->assertSame(count($expectation), $countresults,
-                    'Failed number of ' . $type . ' for line ' . $line . '.' . $info);
+            $this->assertSame(
+                count($expectation),
+                $countresults,
+                'Failed number of ' . $type . ' for line ' . $line . '.' . $info
+            );
             // Now verify every expectation requiring matching.
             foreach ($expectation as $key => $expectedcontent) {
                 if (is_string($expectedcontent)) {
-                    $this->assertStringContainsString($expectedcontent, $results[$line][$key],
-                        'Failed contents matching of ' . $type . ' for element ' . ($key + 1) . ' of line ' . $line . '.');
+                    $this->assertStringContainsString(
+                        $expectedcontent,
+                        $results[$line][$key],
+                        'Failed contents matching of ' . $type . ' for element ' . ($key + 1) . ' of line ' . $line . '.'
+                    );
                 }
             }
             // Delete this line from results.
             unset($results[$line]);
         }
         // Ended looping, verify there aren't remaining results (errors, warnings).
-        $this->assertSame(array(), $results,
-                'Failed to verify that all the ' . $type . ' have been defined by expectations.');
+        $this->assertSame(
+            [],
+            $results,
+            'Failed to verify that all the ' . $type . ' have been defined by expectations.'
+        );
     }
 
     /**
@@ -354,14 +362,14 @@ abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase {
      * @return array normalized array.
      */
     private function normalize_cs_results($results) {
-        $normalized = array();
+        $normalized = [];
         foreach ($results as $line => $lineerrors) {
             foreach ($lineerrors as $errors) {
                 foreach ($errors as $error) {
                     if (isset($normalized[$line])) {
                         $normalized[$line][] = '@Message: ' . $error['message'] . ' @Source: ' . $error['source'];
                     } else {
-                        $normalized[$line] = array('@Message: ' . $error['message'] . ' @Source: ' . $error['source']);
+                        $normalized[$line] = ['@Message: ' . $error['message'] . ' @Source: ' . $error['source']];
                     }
                 }
             }

--- a/moodle/Tests/MoodleStandardTest.php
+++ b/moodle/Tests/MoodleStandardTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,32 +13,28 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test various "moodle" phpcs standard sniffs.
  *
  * Each case covers one sniff. Self-explanatory
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2013 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2013 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @todo Complete coverage of all Sniffs.
  */
-class MoodleStandardTest extends MoodleCSBaseTestCase {
-
+class MoodleStandardTest extends MoodleCSBaseTestCase
+{
     /**
      * Test the PSR12.Functions.ReturnTypeDeclaration sniff.
      *
      * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions\ReturnTypeDeclarationSniff
      */
-    public function test_psr12_functions_returntypedeclaration() {
+    public function testPSR12FunctionsReturnTypeDeclaration() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -66,7 +63,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions\NullableTypeDeclarationSniff
      */
-    public function test_psr12_functions_nullabletypedeclaration() {
+    public function testPSR12FunctionsNullableTypeDeclaration() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -94,7 +91,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff
      */
-    public function test_psr2_methods_methoddeclaration() {
+    public function testPSR2MethodsMethodDeclaration() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -105,21 +102,22 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
+        $this->set_errors([
             33 => 'The static declaration must come after the visibility',
             34 => 1,
             35 => 1,
             37 => 'The final declaration must precede the visibility',
             38 => 1,
             39 => 1,
-            41 => array('FinalAfterVisibility', 'StaticBeforeVisibility'),
+            41 => ['FinalAfterVisibility', 'StaticBeforeVisibility'],
             42 => 2,
             43 => 2,
             45 => 'The abstract declaration must precede the visibility',
             46 => 1,
-            48 => array('AbstractAfterVisibility', 'StaticBeforeVisibility'),
-            49 => 2));
-        $this->set_warnings(array());
+            48 => ['AbstractAfterVisibility', 'StaticBeforeVisibility'],
+            49 => 2,
+        ]);
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -130,7 +128,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Commenting\InlineCommentSniff
      */
-    public function test_moodle_commenting_inlinecomment() {
+    public function testMoodleCommentingInlineComment() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -142,7 +140,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
         $this->set_errors([
-            4 => array('3 slashes comments are not allowed'),
+            4 => ['3 slashes comments are not allowed'],
             6 => 1,
             8 => 'No space found before comment text',
            28 => 'Inline doc block comments are not allowed; use "// Comment." instead',
@@ -169,15 +167,15 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         ]);
         $this->set_warnings([
             4 => 0,
-            6 => array(null, 'Commenting.InlineComment.InvalidEndChar'),
-           55 => array('19 found'),
-           57 => array('121 found'),
-           59 => array('Found: (no)'),
+            6 => [null, 'Commenting.InlineComment.InvalidEndChar'],
+           55 => ['19 found'],
+           57 => ['121 found'],
+           59 => ['Found: (no)'],
            61 => 1,
            63 => 1,
            65 => 1,
            67 => 1,
-           69 => array('WrongCommentCodeFoundBefore'),
+           69 => ['WrongCommentCodeFoundBefore'],
            71 => 3,
            75 => 2,
            77 => 1,
@@ -200,7 +198,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Commenting\InlineCommentSniff
      */
-    public function test_moodle_commenting_inlinecomment_js() {
+    public function testMoodleCommentingInlineCommentJS() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -211,14 +209,14 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
-            1 => array('3 slashes comments are not allowed'),
+        $this->set_errors([
+            1 => ['3 slashes comments are not allowed'],
             3 => 1,
             5 => 'No space found before comment text',
-        ));
-        $this->set_warnings(array(
-            3 => array(null, 'Commenting.InlineComment.InvalidEndChar'),
-        ));
+        ]);
+        $this->set_warnings([
+            3 => [null, 'Commenting.InlineComment.InvalidEndChar'],
+        ]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -229,7 +227,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\ControlStructures\ControlSignatureSniff
      */
-    public function test_moodle_controlstructures_controlsignature() {
+    public function testMoodleControlStructuresControlsignature() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -240,12 +238,13 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
+        $this->set_errors([
             3 => 0,
-            4 => array('found "if(...) {'),
+            4 => ['found "if(...) {'],
             5 => 0,
-            6 => '@Message: Expected "} else {\n"'));
-        $this->set_warnings(array());
+            6 => '@Message: Expected "} else {\n"',
+        ]);
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -256,7 +255,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\LineLengthSniff
      */
-    public function test_moodle_files_linelength() {
+    public function testMoodleFilesLineLength() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -267,14 +266,16 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
+        $this->set_errors([
             21 => 'maximum limit of 180 characters; contains 181 characters',
-            22 => 'maximum limit of 180 characters; contains 181 characters'));
-        $this->set_warnings(array(
+            22 => 'maximum limit of 180 characters; contains 181 characters',
+        ]);
+        $this->set_warnings([
             13 => 'exceeds 132 characters; contains 133 characters',
             14 => 'exceeds 132 characters; contains 133 characters',
             17 => 'exceeds 132 characters; contains 180 characters',
-            18 => 'exceeds 132 characters; contains 180 characters'));
+            18 => 'exceeds 132 characters; contains 180 characters',
+        ]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -285,7 +286,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\DisallowLongArraySyntaxSniff
      */
-    public function test_generic_array_disallowlongarraysyntax(): void {
+    public function testGenericArraysDisallowLongArraySyntax(): void {
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
         $this->set_sniff('Generic.Arrays.DisallowLongArraySyntax');
@@ -301,7 +302,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
             9 => 'Short array syntax must be used to define arrays @Source: Generic.Arrays.DisallowLongArraySyntax.Found',
         ]);
 
-        $this->set_warnings(array());
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -312,7 +313,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineEndingsSniff
      */
-    public function test_generic_files_lineendings() {
+    public function testGeneriFilesLineEndings() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -323,10 +324,11 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
-            1 => 'line character is invalid; expected "\n" but found "\r\n" @Source: Generic.Files.LineEndings.InvalidEOLChar'));
+        $this->set_errors([
+            1 => 'line character is invalid; expected "\n" but found "\r\n" @Source: Generic.Files.LineEndings.InvalidEOLChar',
+        ]);
 
-        $this->set_warnings(array());
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -337,7 +339,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\EndFileNewlineSniff
      */
-    public function test_generic_files_endfilenewline() {
+    public function testGenericFilesEndFileNewLine() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -348,10 +350,11 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
-            4 => 'File must end with a newline character @Source: Generic.Files.EndFileNewline.NotFound'));
+        $this->set_errors([
+            4 => 'File must end with a newline character @Source: Generic.Files.EndFileNewline.NotFound',
+        ]);
 
-        $this->set_warnings(array());
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -362,7 +365,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Whitespace\DisallowTabIndentSniff
      */
-    public function test_generic_whitespace_disalowtabindent() {
+    public function testGenericWhiteSpaceDisalowTabIndent() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -373,12 +376,13 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
+        $this->set_errors([
             9 => 'Spaces must be used to indent lines; tabs are not allowed',
            10 => 1,
-           11 => 1));
+           11 => 1,
+        ]);
 
-        $this->set_warnings(array());
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -389,7 +393,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\OpeningFunctionBraceKernighanRitchieSniff
      */
-    public function test_generic_functions_openingfunctionbracekerninghanritchie() {
+    public function testGenericFunctionsOpeningFunctionBraceKernighanRitchie() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -400,7 +404,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
+        $this->set_errors([
             6 => 'Expected 1 space before opening brace; found 0',
             9 => 1,
            12 => 'Expected 1 space before opening brace; found 3',
@@ -408,9 +412,9 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
            20 => 'Expected 1 space before opening brace; found 0',
            23 => 1,
            26 => 'Expected 1 space before opening brace; found 3',
-           29 => 1));
+           29 => 1]);
 
-        $this->set_warnings(array());
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -421,7 +425,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\Classes\OpeningBraceSameLineSniff
      */
-    public function test_generic_classes_openingclassbrace() {
+    public function testGenericClassesOpeningBraceSameLine() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -451,7 +455,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ScopeIndentSniff
      */
-    public function test_generic_whitespace_scopeindent() {
+    public function testGenericWhiteSpaceScopeIndent() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -462,12 +466,12 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
+        $this->set_errors([
             7 => 'indented incorrectly; expected at least 4 spaces, found 2 @Source: Generic.WhiteSpace.ScopeIndent.Incorrect',
             19 => 'indented incorrectly; expected at least 4 spaces, found 2 @Source: Generic.WhiteSpace.ScopeIndent.Incorrect',
             44 => 'expected at least 8 spaces',
-        ));
-        $this->set_warnings(array());
+        ]);
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -478,7 +482,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHP\DeprecatedFunctionsSniff
      */
-    public function test_moodle_php_deprecatedfunctions() {
+    public function testMoodlePHPDeprecatedFunctions() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -489,8 +493,8 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array());
-        $warnings = array(7 => 'print_error() has been deprecated; use throw new moodle_exception()');
+        $this->set_errors([]);
+        $warnings = [7 => 'print_error() has been deprecated; use throw new moodle_exception()'];
         if (PHP_VERSION_ID >= 70300 && PHP_VERSION_ID < 80000) {
             $warnings[10] = 'mbsplit() has been deprecated';
         }
@@ -505,7 +509,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHP\ForbiddenFunctionsSniff
      */
-    public function test_moodle_php_forbiddenfunctions() {
+    public function testMoodlePHPForbiddenFunctions() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -516,7 +520,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
+        $this->set_errors([
             5 => 'function sizeof() is forbidden; use count()',
             6 => 1,
             8 => 1,
@@ -527,8 +531,8 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
             15 => 0,
             16 => 0,
             17 => 0,
-            ));
-        $this->set_warnings(array());
+            ]);
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -539,7 +543,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHP\ForbiddenGlobalUseSniff
      */
-    public function test_moodle_php_forbidden_global_use() {
+    public function testMoodlePHPForbiddenGlobalUse() {
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
         $this->set_sniff('moodle.PHP.ForbiddenGlobalUse');
@@ -623,7 +627,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHP\ForbiddenTokensSniff
      */
-    public function test_moodle_php_forbiddentokens() {
+    public function testMoodlePHPForbiddenTokens() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -634,13 +638,13 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
+        $this->set_errors([
             5 => 'The use of function eval() is forbidden',
             6 => 'The use of operator goto is forbidden',
             8 => 'The use of goto labels is forbidden',
             11 => 1,
-            13 => array('backticks', 'backticks')));
-        $this->set_warnings(array());
+            13 => ['backticks', 'backticks']]);
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -651,7 +655,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Strings\ForbiddenStringsSniff
      */
-    public function test_moodle_strings_forbiddenstrings() {
+    public function testMoodleStringsForbiddenStrings() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -662,7 +666,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
+        $this->set_errors([
             8 => 'The use of the AS keyword to alias tables is bad for cross-db',
             10 => 1,
             11 => 'The use of the AS keyword to alias tables is bad for cross-db',
@@ -673,13 +677,13 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
             16 => (version_compare(PHP_VERSION, '7.3.0', '<') ? 1 : 0),
             23 => (version_compare(PHP_VERSION, '7.3.0', '<') ? 2 : 1),
             26 => 0,
-            27 => 0));
-        $this->set_warnings(array(
-            19 => array('backticks in strings is not recommended'),
+            27 => 0]);
+        $this->set_warnings([
+            19 => ['backticks in strings is not recommended'],
             20 => 1,
             23 => 1,
             36 => 'backticks in strings',
-            37 => 1));
+            37 => 1]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -690,7 +694,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHPCompatibility\Sniffs\FunctionUse\RemovedFunctionsSniff
      */
-    public function test_phpcompatibility_php_deprecatedfunctions() {
+    public function testPHPCompatibilityFunctionUseRemovedFunctions() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -701,10 +705,10 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
-            5 => array('Function ereg_replace', 'Use call_user_func() instead', '@Source: PHPCompat')
-        ));
-        $this->set_warnings(array());
+        $this->set_errors([
+            5 => ['Function ereg_replace', 'Use call_user_func() instead', '@Source: PHPCompat'],
+        ]);
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -715,7 +719,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHPCompatibility\Sniffs\Syntax\ForbiddenCallTimePassByReferenceSniff
      */
-    public function test_phpcompatibility_php_forbiddencalltimepassbyreference() {
+    public function testPHPCompatibilitySyntaxForbiddenCallTimePassByReference() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -726,10 +730,10 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
-            6 => array('call-time pass-by-reference is deprecated'),
-            7 => array('@Source: PHPCompat')));
-        $this->set_warnings(array());
+        $this->set_errors([
+            6 => ['call-time pass-by-reference is deprecated'],
+            7 => ['@Source: PHPCompat']]);
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -740,7 +744,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\NamingConventions\ValidVariableNameSniff
      */
-    public function test_moodle_namingconventions_variablename() {
+    public function testMoodleNamingConventionsValidVariableName() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -751,24 +755,24 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
+        $this->set_errors([
             4 => 'must not contain underscores',
             5 => 'must be all lower-case',
             6 => 'must not contain underscores',
-            7 => array('must be all lower-case', 'must not contain underscores'),
+            7 => ['must be all lower-case', 'must not contain underscores'],
             8 => 0,
             9 => 0,
             12 => 'must not contain underscores',
             13 => 'must be all lower-case',
-            14 => array('must be all lower-case', 'must not contain underscores'),
+            14 => ['must be all lower-case', 'must not contain underscores'],
             15 => 0,
             16 => 0,
             17 => 'The \'var\' keyword is not permitted',
             20 => 'must be all lower-case',
             21 => 2,
-            22 => array('must be all lower-case', 'must not contain underscores'),
-        ));
-        $this->set_warnings(array());
+            22 => ['must be all lower-case', 'must not contain underscores'],
+        ]);
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -779,7 +783,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff
      */
-    public function test_squiz_operator_spacing() {
+    public function testSquizWhiteSpaceOperatorSpacing() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -790,18 +794,18 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
+        $this->set_errors([
                                6 => 0,
                                7 => 'Expected 1 space before',
                                8 => 'Expected 1 space after',
-                               9 => array('Expected 1 space before', 'Expected 1 space after'),
+                               9 => ['Expected 1 space before', 'Expected 1 space after'],
                                10 => 0,
                                11 => 'Expected 1 space after "=>"; 3 found',
                                12 => 0,
                                13 => 0,
                                14 => 'Expected 1 space before',
                                15 => 'Expected 1 space after',
-                               16 => array('Expected 1 space before', 'Expected 1 space after'),
+                               16 => ['Expected 1 space before', 'Expected 1 space after'],
                                17 => 0,
                                18 => 'Expected 1 space after "="; 2 found',
                                19 => 0,
@@ -809,28 +813,28 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
                                21 => 0,
                                22 => 'Expected 1 space before',
                                23 => 'Expected 1 space after',
-                               24 => array('Expected 1 space before', 'Expected 1 space after'),
+                               24 => ['Expected 1 space before', 'Expected 1 space after'],
                                25 => 0,
                                26 => 'Expected 1 space after "+"; 2 found',
                                27 => 'Expected 1 space before "+"; 2 found',
                                28 => 0,
                                29 => 'Expected 1 space before',
                                30 => 'Expected 1 space after',
-                               31 => array('Expected 1 space before', 'Expected 1 space after'),
+                               31 => ['Expected 1 space before', 'Expected 1 space after'],
                                32 => 0,
                                33 => 'Expected 1 space after "-"; 2 found',
                                34 => 'Expected 1 space before "-"; 2 found',
                                35 => 0,
                                36 => 'Expected 1 space before',
                                37 => 'Expected 1 space after',
-                               38 => array('Expected 1 space before', 'Expected 1 space after'),
+                               38 => ['Expected 1 space before', 'Expected 1 space after'],
                                39 => 0,
                                40 => 'Expected 1 space after "*"; 2 found',
                                41 => 'Expected 1 space before "*"; 2 found',
                                42 => 0,
                                43 => 'Expected 1 space before',
                                44 => 'Expected 1 space after',
-                               45 => array('Expected 1 space before', 'Expected 1 space after'),
+                               45 => ['Expected 1 space before', 'Expected 1 space after'],
                                46 => 0,
                                47 => 'Expected 1 space after "/"; 2 found',
                                48 => 'Expected 1 space before "/"; 2 found',
@@ -848,9 +852,9 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
                                60 => 0,
                                61 => 0,
                                62 => 0,
-                               63 => 0
-                          ));
-        $this->set_warnings(array());
+                               63 => 0,
+                          ]);
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -861,7 +865,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ObjectOperatorSpacingSniff
      */
-    public function test_squiz_object_operator_spacing() {
+    public function testSquizWhiteSpaceObjectOperatorSpacing() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -872,8 +876,8 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array());
-        $this->set_warnings(array());
+        $this->set_errors([]);
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -884,7 +888,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHP_CodeSniffer\Standards\PEAR\Sniffs\WhiteSpace\ObjectOperatorIndentSniff
      */
-    public function test_pear_object_operator_indent() {
+    public function testPEARWhiteSpaceObjectOperatorIndent() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -895,7 +899,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array(
+        $this->set_errors([
             40 => 'not indented correctly; expected 4 spaces but found 2',
             41 => '@Source: PEAR.WhiteSpace.ObjectOperatorIndent.Incorrect',
             44 => 1,
@@ -910,8 +914,8 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
             66 => 1,
             69 => 1,
             70 => 1,
-        ));
-        $this->set_warnings(array());
+        ]);
+        $this->set_warnings([]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -922,7 +926,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\CommentedOutCodeSniff
      */
-    public function test_squid_php_commentedoutcode() {
+    public function testSquizPHPCommentedOutCode() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
@@ -933,11 +937,11 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors(array());
-        $this->set_warnings(array(
+        $this->set_errors([]);
+        $this->set_warnings([
             5 => 'This comment is 72% valid code; is this commented out code',
-            9 => '@Source: Squiz.PHP.CommentedOutCode.Found'
-        ));
+            9 => '@Source: Squiz.PHP.CommentedOutCode.Found',
+        ]);
 
         // Let's do all the hard work!
         $this->verify_cs_results();
@@ -948,15 +952,15 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\RequireLoginSniff
      */
-    public function test_moodle_files_requirelogin_problem() {
+    public function testMoodleFilesRequireLoginProblem() {
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.RequireLogin');
         $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/problem.php');
 
-        $this->set_errors(array());
-        $this->set_warnings(array(
-            25 => ', require_course_login, require_admin, admin_externalpage_setup) following config inclusion. None found'
-        ));
+        $this->set_errors([]);
+        $this->set_warnings([
+            25 => ', require_course_login, require_admin, admin_externalpage_setup) following config inclusion. None found',
+        ]);
 
         $this->verify_cs_results();
     }
@@ -966,13 +970,13 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\RequireLoginSniff
      */
-    public function test_moodle_files_requirelogin_require_login_ok() {
+    public function testMoodleFilesRequireLoginOk() {
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.RequireLogin');
         $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/require_login_ok.php');
 
-        $this->set_errors(array());
-        $this->set_warnings(array());
+        $this->set_errors([]);
+        $this->set_warnings([]);
 
         $this->verify_cs_results();
     }
@@ -982,13 +986,13 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\RequireLoginSniff
      */
-    public function test_moodle_files_requirelogin_require_course_login_ok() {
+    public function testMoodleFilesRequireLoginCourseOk() {
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.RequireLogin');
         $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/require_course_login_ok.php');
 
-        $this->set_errors(array());
-        $this->set_warnings(array());
+        $this->set_errors([]);
+        $this->set_warnings([]);
 
         $this->verify_cs_results();
     }
@@ -998,13 +1002,13 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\RequireLoginSniff
      */
-    public function test_moodle_files_requirelogin_admin_externalpage_setup_ok() {
+    public function testMoodleFilesRequireLoginAdminExtenalPageOk() {
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.RequireLogin');
         $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/admin_externalpage_setup_ok.php');
 
-        $this->set_errors(array());
-        $this->set_warnings(array());
+        $this->set_errors([]);
+        $this->set_warnings([]);
 
         $this->verify_cs_results();
     }
@@ -1014,13 +1018,13 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\RequireLoginSniff
      */
-    public function test_moodle_files_requirelogin_cliscript_ok() {
+    public function testMoodleFilesRequireLoginCLIScriptOk() {
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.RequireLogin');
         $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/cliscript_ok.php');
 
-        $this->set_errors(array());
-        $this->set_warnings(array());
+        $this->set_errors([]);
+        $this->set_warnings([]);
 
         $this->verify_cs_results();
     }
@@ -1030,13 +1034,13 @@ class MoodleStandardTest extends MoodleCSBaseTestCase {
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\RequireLoginSniff
      */
-    public function test_moodle_files_requirelogin_nomoodlecookies_ok() {
+    public function testMoodleFilesRequireLoginNoMoodlCookiesOk() {
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Files.RequireLogin');
         $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/nomoodlecookies_ok.php');
 
-        $this->set_errors(array());
-        $this->set_warnings(array());
+        $this->set_errors([]);
+        $this->set_warnings([]);
 
         $this->verify_cs_results();
     }

--- a/moodle/Tests/MoodleStandardTest.php
+++ b/moodle/Tests/MoodleStandardTest.php
@@ -37,9 +37,9 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testPSR12FunctionsReturnTypeDeclaration() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('PSR12.Functions.ReturnTypeDeclaration');
-        $this->set_fixture(__DIR__ . '/fixtures/psr12_functions_returntypedeclaration.php');
+        $this->setStandard('moodle');
+        $this->setSniff('PSR12.Functions.ReturnTypeDeclaration');
+        $this->setFixture(__DIR__ . '/fixtures/psr12_functions_returntypedeclaration.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
@@ -51,11 +51,11 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
             38 => 'SpaceBeforeReturnType',
         ];
         $warnings = [];
-        $this->set_errors($errors);
-        $this->set_warnings($warnings);
+        $this->setErrors($errors);
+        $this->setWarnings($warnings);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -66,9 +66,9 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testPSR12FunctionsNullableTypeDeclaration() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('PSR12.Functions.NullableTypeDeclaration');
-        $this->set_fixture(__DIR__ . '/fixtures/psr12_functions_nullabletypedeclaration.php');
+        $this->setStandard('moodle');
+        $this->setSniff('PSR12.Functions.NullableTypeDeclaration');
+        $this->setFixture(__DIR__ . '/fixtures/psr12_functions_nullabletypedeclaration.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
@@ -79,11 +79,11 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
             22 => 3,
         ];
         $warnings = [];
-        $this->set_errors($errors);
-        $this->set_warnings($warnings);
+        $this->setErrors($errors);
+        $this->setWarnings($warnings);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -94,15 +94,15 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testPSR2MethodsMethodDeclaration() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('PSR2.Methods.MethodDeclaration');
-        $this->set_fixture(__DIR__ . '/fixtures/psr2_methods_methoddeclaration.php');
+        $this->setStandard('moodle');
+        $this->setSniff('PSR2.Methods.MethodDeclaration');
+        $this->setFixture(__DIR__ . '/fixtures/psr2_methods_methoddeclaration.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             33 => 'The static declaration must come after the visibility',
             34 => 1,
             35 => 1,
@@ -117,10 +117,10 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
             48 => ['AbstractAfterVisibility', 'StaticBeforeVisibility'],
             49 => 2,
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -131,15 +131,15 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testMoodleCommentingInlineComment() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Commenting.InlineComment');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_comenting_inlinecomment.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Commenting.InlineComment');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_comenting_inlinecomment.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             4 => ['3 slashes comments are not allowed'],
             6 => 1,
             8 => 'No space found before comment text',
@@ -165,7 +165,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
           144 => '@Source: moodle.Commenting.InlineComment.SpacingBefore',
           146 => '@Message: Blank comments are not allowed',
         ]);
-        $this->set_warnings([
+        $this->setWarnings([
             4 => 0,
             6 => [null, 'Commenting.InlineComment.InvalidEndChar'],
            55 => ['19 found'],
@@ -185,7 +185,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
         ]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -201,25 +201,25 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testMoodleCommentingInlineCommentJS() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Commenting.InlineComment');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_comenting_inlinecomment.js');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Commenting.InlineComment');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_comenting_inlinecomment.js');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             1 => ['3 slashes comments are not allowed'],
             3 => 1,
             5 => 'No space found before comment text',
         ]);
-        $this->set_warnings([
+        $this->setWarnings([
             3 => [null, 'Commenting.InlineComment.InvalidEndChar'],
         ]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -230,24 +230,24 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testMoodleControlStructuresControlsignature() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.ControlStructures.ControlSignature');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_controlstructures_controlsignature.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.ControlStructures.ControlSignature');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_controlstructures_controlsignature.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             3 => 0,
             4 => ['found "if(...) {'],
             5 => 0,
             6 => '@Message: Expected "} else {\n"',
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -258,19 +258,19 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testMoodleFilesLineLength() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.LineLength');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_linelength.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.LineLength');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_files_linelength.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             21 => 'maximum limit of 180 characters; contains 181 characters',
             22 => 'maximum limit of 180 characters; contains 181 characters',
         ]);
-        $this->set_warnings([
+        $this->setWarnings([
             13 => 'exceeds 132 characters; contains 133 characters',
             14 => 'exceeds 132 characters; contains 133 characters',
             17 => 'exceeds 132 characters; contains 180 characters',
@@ -278,7 +278,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
         ]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -288,24 +288,24 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
      */
     public function testGenericArraysDisallowLongArraySyntax(): void {
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('Generic.Arrays.DisallowLongArraySyntax');
-        $this->set_fixture(__DIR__ . '/fixtures/generic_array_longarraysyntax.php');
+        $this->setStandard('moodle');
+        $this->setSniff('Generic.Arrays.DisallowLongArraySyntax');
+        $this->setFixture(__DIR__ . '/fixtures/generic_array_longarraysyntax.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             3 => 'Short array syntax must be used to define arrays @Source: Generic.Arrays.DisallowLongArraySyntax.Found',
             5 => 'Short array syntax must be used to define arrays @Source: Generic.Arrays.DisallowLongArraySyntax.Found',
             9 => 'Short array syntax must be used to define arrays @Source: Generic.Arrays.DisallowLongArraySyntax.Found',
         ]);
 
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -316,22 +316,22 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testGeneriFilesLineEndings() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('Generic.Files.LineEndings');
-        $this->set_fixture(__DIR__ . '/fixtures/generic_files_lineendings.php');
+        $this->setStandard('moodle');
+        $this->setSniff('Generic.Files.LineEndings');
+        $this->setFixture(__DIR__ . '/fixtures/generic_files_lineendings.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             1 => 'line character is invalid; expected "\n" but found "\r\n" @Source: Generic.Files.LineEndings.InvalidEOLChar',
         ]);
 
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -342,22 +342,22 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testGenericFilesEndFileNewLine() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('Generic.Files.EndFileNewline');
-        $this->set_fixture(__DIR__ . '/fixtures/generic_files_endfilenewline.php');
+        $this->setStandard('moodle');
+        $this->setSniff('Generic.Files.EndFileNewline');
+        $this->setFixture(__DIR__ . '/fixtures/generic_files_endfilenewline.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             4 => 'File must end with a newline character @Source: Generic.Files.EndFileNewline.NotFound',
         ]);
 
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -368,24 +368,24 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testGenericWhiteSpaceDisalowTabIndent() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('Generic.WhiteSpace.DisallowTabIndent');
-        $this->set_fixture(__DIR__ . '/fixtures/generic_whitespace_disallowtabindent.php');
+        $this->setStandard('moodle');
+        $this->setSniff('Generic.WhiteSpace.DisallowTabIndent');
+        $this->setFixture(__DIR__ . '/fixtures/generic_whitespace_disallowtabindent.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             9 => 'Spaces must be used to indent lines; tabs are not allowed',
            10 => 1,
            11 => 1,
         ]);
 
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -396,15 +396,15 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testGenericFunctionsOpeningFunctionBraceKernighanRitchie() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('Generic.Functions.OpeningFunctionBraceKernighanRitchie');
-        $this->set_fixture(__DIR__ . '/fixtures/generic_functions_openingfunctionbracekerninghanritchie.php');
+        $this->setStandard('moodle');
+        $this->setSniff('Generic.Functions.OpeningFunctionBraceKernighanRitchie');
+        $this->setFixture(__DIR__ . '/fixtures/generic_functions_openingfunctionbracekerninghanritchie.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             6 => 'Expected 1 space before opening brace; found 0',
             9 => 1,
            12 => 'Expected 1 space before opening brace; found 3',
@@ -414,10 +414,10 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
            26 => 'Expected 1 space before opening brace; found 3',
            29 => 1]);
 
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -428,15 +428,15 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testGenericClassesOpeningBraceSameLine() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('Generic.Classes.OpeningBraceSameLine');
-        $this->set_fixture(__DIR__ . '/fixtures/generic_classes_openingclassbrace.php');
+        $this->setStandard('moodle');
+        $this->setSniff('Generic.Classes.OpeningBraceSameLine');
+        $this->setFixture(__DIR__ . '/fixtures/generic_classes_openingclassbrace.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             5 => 'Expected 1 space before opening brace; found 0',
             8 => 'Expected 1 space before opening brace; found 0',
             11 => 'Expected 1 space before opening brace; found 3',
@@ -444,10 +444,10 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
             19 => 'Opening brace should be on the same line as the declaration for class test05',
         ]);
 
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -458,23 +458,23 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testGenericWhiteSpaceScopeIndent() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('Generic.WhiteSpace.ScopeIndent');
-        $this->set_fixture(__DIR__ . '/fixtures/generic_whitespace_scopeindent.php');
+        $this->setStandard('moodle');
+        $this->setSniff('Generic.WhiteSpace.ScopeIndent');
+        $this->setFixture(__DIR__ . '/fixtures/generic_whitespace_scopeindent.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             7 => 'indented incorrectly; expected at least 4 spaces, found 2 @Source: Generic.WhiteSpace.ScopeIndent.Incorrect',
             19 => 'indented incorrectly; expected at least 4 spaces, found 2 @Source: Generic.WhiteSpace.ScopeIndent.Incorrect',
             44 => 'expected at least 8 spaces',
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -485,23 +485,23 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testMoodlePHPDeprecatedFunctions() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.PHP.DeprecatedFunctions');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_php_deprecatedfunctions.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHP.DeprecatedFunctions');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_php_deprecatedfunctions.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([]);
+        $this->setErrors([]);
         $warnings = [7 => 'print_error() has been deprecated; use throw new moodle_exception()'];
         if (PHP_VERSION_ID >= 70300 && PHP_VERSION_ID < 80000) {
             $warnings[10] = 'mbsplit() has been deprecated';
         }
-        $this->set_warnings($warnings);
+        $this->setWarnings($warnings);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -512,15 +512,15 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testMoodlePHPForbiddenFunctions() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.PHP.ForbiddenFunctions');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_php_forbiddenfunctions.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHP.ForbiddenFunctions');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_php_forbiddenfunctions.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             5 => 'function sizeof() is forbidden; use count()',
             6 => 1,
             8 => 1,
@@ -532,10 +532,10 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
             16 => 0,
             17 => 0,
             ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -545,15 +545,15 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
      */
     public function testMoodlePHPForbiddenGlobalUse() {
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.PHP.ForbiddenGlobalUse');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_php_forbidden_global_use.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHP.ForbiddenGlobalUse');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_php_forbidden_global_use.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
                 1 => 0,
                 2 => 0,
                 3 => 0,
@@ -616,10 +616,10 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
                 58 => 0,
                 59 => 0,
                 ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -630,24 +630,24 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testMoodlePHPForbiddenTokens() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.PHP.ForbiddenTokens');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_php_forbiddentokens.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHP.ForbiddenTokens');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_php_forbiddentokens.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             5 => 'The use of function eval() is forbidden',
             6 => 'The use of operator goto is forbidden',
             8 => 'The use of goto labels is forbidden',
             11 => 1,
             13 => ['backticks', 'backticks']]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -658,15 +658,15 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testMoodleStringsForbiddenStrings() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Strings.ForbiddenStrings');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_strings_forbiddenstrings.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Strings.ForbiddenStrings');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_strings_forbiddenstrings.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             8 => 'The use of the AS keyword to alias tables is bad for cross-db',
             10 => 1,
             11 => 'The use of the AS keyword to alias tables is bad for cross-db',
@@ -678,7 +678,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
             23 => (version_compare(PHP_VERSION, '7.3.0', '<') ? 2 : 1),
             26 => 0,
             27 => 0]);
-        $this->set_warnings([
+        $this->setWarnings([
             19 => ['backticks in strings is not recommended'],
             20 => 1,
             23 => 1,
@@ -686,7 +686,7 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
             37 => 1]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -697,21 +697,21 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testPHPCompatibilityFunctionUseRemovedFunctions() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('PHPCompatibility.FunctionUse.RemovedFunctions');
-        $this->set_fixture(__DIR__ . '/fixtures/phpcompatibility_php_deprecatedfunctions.php');
+        $this->setStandard('moodle');
+        $this->setSniff('PHPCompatibility.FunctionUse.RemovedFunctions');
+        $this->setFixture(__DIR__ . '/fixtures/phpcompatibility_php_deprecatedfunctions.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             5 => ['Function ereg_replace', 'Use call_user_func() instead', '@Source: PHPCompat'],
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -722,21 +722,21 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testPHPCompatibilitySyntaxForbiddenCallTimePassByReference() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('PHPCompatibility.Syntax.ForbiddenCallTimePassByReference');
-        $this->set_fixture(__DIR__ . '/fixtures/phpcompatibility_php_forbiddencalltimepassbyreference.php');
+        $this->setStandard('moodle');
+        $this->setSniff('PHPCompatibility.Syntax.ForbiddenCallTimePassByReference');
+        $this->setFixture(__DIR__ . '/fixtures/phpcompatibility_php_forbiddencalltimepassbyreference.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             6 => ['call-time pass-by-reference is deprecated'],
             7 => ['@Source: PHPCompat']]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -747,15 +747,15 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testMoodleNamingConventionsValidVariableName() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.NamingConventions.ValidVariableName');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_namingconventions_variablename.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.NamingConventions.ValidVariableName');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_namingconventions_variablename.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             4 => 'must not contain underscores',
             5 => 'must be all lower-case',
             6 => 'must not contain underscores',
@@ -772,10 +772,10 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
             21 => 2,
             22 => ['must be all lower-case', 'must not contain underscores'],
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -786,15 +786,15 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testSquizWhiteSpaceOperatorSpacing() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('Squiz.WhiteSpace.OperatorSpacing');
-        $this->set_fixture(__DIR__ . '/fixtures/squiz_whitespace_operatorspacing.php');
+        $this->setStandard('moodle');
+        $this->setSniff('Squiz.WhiteSpace.OperatorSpacing');
+        $this->setFixture(__DIR__ . '/fixtures/squiz_whitespace_operatorspacing.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
                                6 => 0,
                                7 => 'Expected 1 space before',
                                8 => 'Expected 1 space after',
@@ -854,10 +854,10 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
                                62 => 0,
                                63 => 0,
                           ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -868,19 +868,19 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testSquizWhiteSpaceObjectOperatorSpacing() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('Squiz.WhiteSpace.ObjectOperatorSpacing');
-        $this->set_fixture(__DIR__ . '/fixtures/squiz_whitespace_objectoperatorspacing.php');
+        $this->setStandard('moodle');
+        $this->setSniff('Squiz.WhiteSpace.ObjectOperatorSpacing');
+        $this->setFixture(__DIR__ . '/fixtures/squiz_whitespace_objectoperatorspacing.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([]);
-        $this->set_warnings([]);
+        $this->setErrors([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -891,15 +891,15 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testPEARWhiteSpaceObjectOperatorIndent() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('PEAR.WhiteSpace.ObjectOperatorIndent');
-        $this->set_fixture(__DIR__ . '/fixtures/pear_whitespace_objectoperatorspacing.php');
+        $this->setStandard('moodle');
+        $this->setSniff('PEAR.WhiteSpace.ObjectOperatorIndent');
+        $this->setFixture(__DIR__ . '/fixtures/pear_whitespace_objectoperatorspacing.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             40 => 'not indented correctly; expected 4 spaces but found 2',
             41 => '@Source: PEAR.WhiteSpace.ObjectOperatorIndent.Incorrect',
             44 => 1,
@@ -915,10 +915,10 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
             69 => 1,
             70 => 1,
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -929,22 +929,22 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     public function testSquizPHPCommentedOutCode() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('Squiz.PHP.CommentedOutCode');
-        $this->set_fixture(__DIR__ . '/fixtures/squiz_php_commentedoutcode.php');
+        $this->setStandard('moodle');
+        $this->setSniff('Squiz.PHP.CommentedOutCode');
+        $this->setFixture(__DIR__ . '/fixtures/squiz_php_commentedoutcode.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([]);
-        $this->set_warnings([
+        $this->setErrors([]);
+        $this->setWarnings([
             5 => 'This comment is 72% valid code; is this commented out code',
             9 => '@Source: Squiz.PHP.CommentedOutCode.Found',
         ]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -953,16 +953,16 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\RequireLoginSniff
      */
     public function testMoodleFilesRequireLoginProblem() {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.RequireLogin');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/problem.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.RequireLogin');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_files_requirelogin/problem.php');
 
-        $this->set_errors([]);
-        $this->set_warnings([
+        $this->setErrors([]);
+        $this->setWarnings([
             25 => ', require_course_login, require_admin, admin_externalpage_setup) following config inclusion. None found',
         ]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -971,14 +971,14 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\RequireLoginSniff
      */
     public function testMoodleFilesRequireLoginOk() {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.RequireLogin');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/require_login_ok.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.RequireLogin');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_files_requirelogin/require_login_ok.php');
 
-        $this->set_errors([]);
-        $this->set_warnings([]);
+        $this->setErrors([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -987,14 +987,14 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\RequireLoginSniff
      */
     public function testMoodleFilesRequireLoginCourseOk() {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.RequireLogin');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/require_course_login_ok.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.RequireLogin');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_files_requirelogin/require_course_login_ok.php');
 
-        $this->set_errors([]);
-        $this->set_warnings([]);
+        $this->setErrors([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -1003,14 +1003,14 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\RequireLoginSniff
      */
     public function testMoodleFilesRequireLoginAdminExtenalPageOk() {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.RequireLogin');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/admin_externalpage_setup_ok.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.RequireLogin');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_files_requirelogin/admin_externalpage_setup_ok.php');
 
-        $this->set_errors([]);
-        $this->set_warnings([]);
+        $this->setErrors([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -1019,14 +1019,14 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\RequireLoginSniff
      */
     public function testMoodleFilesRequireLoginCLIScriptOk() {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.RequireLogin');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/cliscript_ok.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.RequireLogin');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_files_requirelogin/cliscript_ok.php');
 
-        $this->set_errors([]);
-        $this->set_warnings([]);
+        $this->setErrors([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**
@@ -1035,13 +1035,13 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\RequireLoginSniff
      */
     public function testMoodleFilesRequireLoginNoMoodlCookiesOk() {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.RequireLogin');
-        $this->set_fixture(__DIR__ . '/fixtures/moodle_files_requirelogin/nomoodlecookies_ok.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.RequireLogin');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_files_requirelogin/nomoodlecookies_ok.php');
 
-        $this->set_errors([]);
-        $this->set_warnings([]);
+        $this->setErrors([]);
+        $this->setWarnings([]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/NamingConventionsValidFunctionNameTest.php
+++ b/moodle/Tests/NamingConventionsValidFunctionNameTest.php
@@ -78,18 +78,18 @@ class NamingConventionsValidFunctionNameTest extends MoodleCSBaseTestCase
     public function testNamingConventionsValidFunctionName(string $fixture, array $errors, array $warnings) {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.NamingConventions.ValidFunctionName');
-        $this->set_fixture(__DIR__ . '/' . $fixture);
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.NamingConventions.ValidFunctionName');
+        $this->setFixture(__DIR__ . '/' . $fixture);
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors($errors);
-        $this->set_warnings($warnings);
+        $this->setErrors($errors);
+        $this->setWarnings($warnings);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/NamingConventionsValidFunctionNameTest.php
+++ b/moodle/Tests/NamingConventionsValidFunctionNameTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,30 +13,26 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
 
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 
-// phpcs:disable moodle.NamingConventions
-
 /**
  * Test the ValidFunctionName sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\NamingConventions\ValidFunctionNameSniff
  */
-class NamingConventionsValidFunctionNameTest extends MoodleCSBaseTestCase {
-
+class NamingConventionsValidFunctionNameTest extends MoodleCSBaseTestCase
+{
     /**
-     * Data provider for self::test_namingconventions_validfunctionname
+     * Data provider for self::testNamingConventionsValidFunctionName
      */
-    public function provider_namingconventions_validfunctionname() {
+    public function providerNamingConventionsValidFunctionName() {
         return [
             'Correct' => [
                 'fixture' => 'fixtures/namingconventions/validfunctionname_correct.php',
@@ -76,9 +73,9 @@ class NamingConventionsValidFunctionNameTest extends MoodleCSBaseTestCase {
      * @param string $fixture relative path to fixture to use.
      * @param array $errors array of errors expected.
      * @param array $warnings array of warnings expected.
-     * @dataProvider provider_namingconventions_validfunctionname
+     * @dataProvider providerNamingConventionsValidFunctionName
      */
-    public function test_namingconventions_validfunctionname(string $fixture, array $errors, array $warnings) {
+    public function testNamingConventionsValidFunctionName(string $fixture, array $errors, array $warnings) {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');

--- a/moodle/Tests/NormalizedArraysArraysCommaAfterLastTest.php
+++ b/moodle/Tests/NormalizedArraysArraysCommaAfterLastTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,19 +13,15 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test the \PHPCSExtra\NormalizedArrays\Sniffs\Arrays\CommaAfterLastSniff sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2023 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2023 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \PHPCSExtra\NormalizedArrays\Sniffs\Arrays\CommaAfterLastSniff
  */

--- a/moodle/Tests/NormalizedArraysArraysCommaAfterLastTest.php
+++ b/moodle/Tests/NormalizedArraysArraysCommaAfterLastTest.php
@@ -33,24 +33,24 @@ class NormalizedArraysArraysCommaAfterLastTest extends MoodleCSBaseTestCase
     public function testNormalizedArraysArraysCommaAfterLast() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('NormalizedArrays.Arrays.CommaAfterLast');
-        $this->set_fixture(__DIR__ . '/fixtures/normalizedarrays_arrays_commaafterlast.php');
+        $this->setStandard('moodle');
+        $this->setSniff('NormalizedArrays.Arrays.CommaAfterLast');
+        $this->setFixture(__DIR__ . '/fixtures/normalizedarrays_arrays_commaafterlast.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             79 => '@Source: NormalizedArrays.Arrays.CommaAfterLast.FoundSingleLine',
             82 => '@Source: NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLine',
             87 => 1,
             95 => 1,
             97 => 1,
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/PHPIncludingFileTest.php
+++ b/moodle/Tests/PHPIncludingFileTest.php
@@ -29,15 +29,15 @@ class PHPIncludingFileTest extends MoodleCSBaseTestCase
 {
     public function testPHPIncludingFile() {
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.PHP.IncludingFile');
-        $this->set_fixture(__DIR__ . '/fixtures/php/includingfile.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHP.IncludingFile');
+        $this->setFixture(__DIR__ . '/fixtures/php/includingfile.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             9 => '@Message: "require" must be immediately followed by an open parenthesis',
            10 => '@Source: moodle.PHP.IncludingFile.BracketsRequired',
            13 => 1,
@@ -45,9 +45,9 @@ class PHPIncludingFileTest extends MoodleCSBaseTestCase
            17 =>  '@Source: moodle.PHP.IncludingFile.UseRequire',
            18 => '@Source: moodle.PHP.IncludingFile.UseRequireOnce',
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/PHPIncludingFileTest.php
+++ b/moodle/Tests/PHPIncludingFileTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,25 +13,21 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test the IncludingFile sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHP\IncludingFileSniff
  */
-class PHPIncludingFileTest extends MoodleCSBaseTestCase {
-
-    public function test_php_includingfile() {
+class PHPIncludingFileTest extends MoodleCSBaseTestCase
+{
+    public function testPHPIncludingFile() {
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
         $this->set_sniff('moodle.PHP.IncludingFile');

--- a/moodle/Tests/PHPMemberVarScopeTest.php
+++ b/moodle/Tests/PHPMemberVarScopeTest.php
@@ -29,21 +29,21 @@ class PHPMemberVarScopeTest extends MoodleCSBaseTestCase
 {
     public function testPHPMemberVarScope() {
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.PHP.MemberVarScope');
-        $this->set_fixture(__DIR__ . '/fixtures/php/membervarscope.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHP.MemberVarScope');
+        $this->setFixture(__DIR__ . '/fixtures/php/membervarscope.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             8 => '@Message: Scope modifier not specified for member variable "$missingprop"',
             9 => '@Source: moodle.PHP.MemberVarScope.Missing',
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/PHPMemberVarScopeTest.php
+++ b/moodle/Tests/PHPMemberVarScopeTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,25 +13,21 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test the IncludingFile sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHP\MemberVarScopeSniff
  */
-class PHPMemberVarScopeTest extends MoodleCSBaseTestCase {
-
-    public function test_php_membervarscope() {
+class PHPMemberVarScopeTest extends MoodleCSBaseTestCase
+{
+    public function testPHPMemberVarScope() {
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
         $this->set_sniff('moodle.PHP.MemberVarScope');

--- a/moodle/Tests/PHPUnitTestCaseCoversTest.php
+++ b/moodle/Tests/PHPUnitTestCaseCoversTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,30 +13,26 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
 
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 
-// phpcs:disable moodle.NamingConventions
-
 /**
  * Test the TestCaseCoversSniff sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit\TestCaseCoversSniff
  */
-class PHPUnitTestCaseCoversTest extends MoodleCSBaseTestCase {
-
+class PHPUnitTestCaseCoversTest extends MoodleCSBaseTestCase
+{
     /**
-     * Data provider for self::test_phpunit_testcasecovers
+     * Data provider for self::testPHPUnitTestCaseCovers
      */
-    public function provider_phpunit_testcasecovers() {
+    public function phpunitTestCaseCoversProvider() {
         return [
             'Correct' => [
                 'fixture' => 'fixtures/phpunit/testcasecovers_correct.php',
@@ -124,9 +121,9 @@ class PHPUnitTestCaseCoversTest extends MoodleCSBaseTestCase {
      * @param string $fixture relative path to fixture to use.
      * @param array $errors array of errors expected.
      * @param array $warnings array of warnings expected.
-     * @dataProvider provider_phpunit_testcasecovers
+     * @dataProvider phpunitTestCaseCoversProvider
      */
-    public function test_phpunit_testcasecovers(string $fixture, array $errors, array $warnings) {
+    public function testPHPUnitTestCaseCovers(string $fixture, array $errors, array $warnings) {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');

--- a/moodle/Tests/PHPUnitTestCaseCoversTest.php
+++ b/moodle/Tests/PHPUnitTestCaseCoversTest.php
@@ -126,18 +126,18 @@ class PHPUnitTestCaseCoversTest extends MoodleCSBaseTestCase
     public function testPHPUnitTestCaseCovers(string $fixture, array $errors, array $warnings) {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.PHPUnit.TestCaseCovers');
-        $this->set_fixture(__DIR__ . '/' . $fixture);
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHPUnit.TestCaseCovers');
+        $this->setFixture(__DIR__ . '/' . $fixture);
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors($errors);
-        $this->set_warnings($warnings);
+        $this->setErrors($errors);
+        $this->setWarnings($warnings);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/PHPUnitTestCaseNamesTest.php
+++ b/moodle/Tests/PHPUnitTestCaseNamesTest.php
@@ -150,10 +150,10 @@ class PHPUnitTestCaseNamesTest extends MoodleCSBaseTestCase
      */
     public function testPHPUnitTestCaseNames(string $fixture, array $errors, array $warnings) {
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.PHPUnit.TestCaseNames');
-        $this->set_fixture(__DIR__ . '/' . $fixture);
-        $this->set_component_mapping([
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHPUnit.TestCaseNames');
+        $this->setFixture(__DIR__ . '/' . $fixture);
+        $this->setComponentMapping([
             'local_codechecker' => dirname(__DIR__),
         ]);
 
@@ -161,10 +161,10 @@ class PHPUnitTestCaseNamesTest extends MoodleCSBaseTestCase
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors($errors);
-        $this->set_warnings($warnings);
+        $this->setErrors($errors);
+        $this->setWarnings($warnings);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/PHPUnitTestCaseNamesTest.php
+++ b/moodle/Tests/PHPUnitTestCaseNamesTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,30 +13,24 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
-
-use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test the TestCaseNamesSniff sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit\TestCaseNamesSniff
  */
-class PHPUnitTestCaseNamesTest extends MoodleCSBaseTestCase {
-
+class PHPUnitTestCaseNamesTest extends MoodleCSBaseTestCase
+{
     /**
-     * Data provider for self::test_phpunit_testcasenames
+     * Data provider for self::testPHPUnitTestCaseNamesProvider
      */
-    public function provider_phpunit_testcasenames() {
+    public function phpunitTestCaseNamesProvider() {
         return [
             'Missing' => [
                 'fixture' => 'fixtures/phpunit/testcasenames_missing.php',
@@ -78,7 +73,7 @@ class PHPUnitTestCaseNamesTest extends MoodleCSBaseTestCase {
                     8 => 1,
                 ],
                 'warnings' => [
-                    2 => 'does not match its expected location at "tests/level2/level3"'
+                    2 => 'does not match its expected location at "tests/level2/level3"',
                 ],
             ],
             'CorrectLevel2NS' => [
@@ -126,7 +121,7 @@ class PHPUnitTestCaseNamesTest extends MoodleCSBaseTestCase {
                     ],
                 ],
                 'warnings' => [
-                    7 => 1
+                    7 => 1,
                 ],
             ],
             'ExistsProposed' => [
@@ -138,7 +133,7 @@ class PHPUnitTestCaseNamesTest extends MoodleCSBaseTestCase {
                     ],
                 ],
                 'warnings' => [
-                    7 => 1
+                    7 => 1,
                 ],
             ],
         ];
@@ -150,10 +145,10 @@ class PHPUnitTestCaseNamesTest extends MoodleCSBaseTestCase {
      * @param string $fixture relative path to fixture to use.
      * @param array $errors array of errors expected.
      * @param array $warnings array of warnings expected.
-     * @dataProvider provider_phpunit_testcasenames
+     * @dataProvider phpunitTestCaseNamesProvider
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit\TestCaseNamesSniff
      */
-    public function test_phpunit_testcasenames(string $fixture, array $errors, array $warnings) {
+    public function testPHPUnitTestCaseNames(string $fixture, array $errors, array $warnings) {
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
         $this->set_sniff('moodle.PHPUnit.TestCaseNames');

--- a/moodle/Tests/PHPUnitTestCaseProviderTest.php
+++ b/moodle/Tests/PHPUnitTestCaseProviderTest.php
@@ -138,18 +138,18 @@ class PHPUnitTestCaseProviderTest extends MoodleCSBaseTestCase
         array $warnings
     ): void {
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.PHPUnit.TestCaseProvider');
-        $this->set_fixture(__DIR__ . '/' . $fixture);
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHPUnit.TestCaseProvider');
+        $this->setFixture(__DIR__ . '/' . $fixture);
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors($errors);
-        $this->set_warnings($warnings);
+        $this->setErrors($errors);
+        $this->setWarnings($warnings);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/PHPUnitTestCaseProviderTest.php
+++ b/moodle/Tests/PHPUnitTestCaseProviderTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,30 +13,24 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
-
-use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test the TestCaseCoversSniff sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit\TestCaseProviderSniff
  */
-class PHPUnitTestCaseProviderTest extends MoodleCSBaseTestCase {
-
+class PHPUnitTestCaseProviderTest extends MoodleCSBaseTestCase
+{
     /**
-     * Data provider for self::test_phpunit_test_providers
+     * Data provider for self::testPHPUnitTestCaseProvider
      */
-    public function provider_phpunit_data_providers() {
+    public function phpunitTestCaseProviderProvider() {
         return [
             'Correct' => [
                 'fixture' => 'fixtures/phpunit/provider/correct_test.php',
@@ -135,9 +130,9 @@ class PHPUnitTestCaseProviderTest extends MoodleCSBaseTestCase {
      * @param string $fixture relative path to fixture to use.
      * @param array $errors array of errors expected.
      * @param array $warnings array of warnings expected.
-     * @dataProvider provider_phpunit_data_providers
+     * @dataProvider phpunitTestCaseProviderProvider
      */
-    public function test_phpunit_test_providers(
+    public function testPHPUnitTestCaseProvider(
         string $fixture,
         array $errors,
         array $warnings

--- a/moodle/Tests/PHPUnitTestReturnTypeTest.php
+++ b/moodle/Tests/PHPUnitTestReturnTypeTest.php
@@ -60,18 +60,18 @@ class PHPUnitTestReturnTypeTest extends MoodleCSBaseTestCase
         array $warnings
     ): void {
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.PHPUnit.TestReturnType');
-        $this->set_fixture(__DIR__ . '/' . $fixture);
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHPUnit.TestReturnType');
+        $this->setFixture(__DIR__ . '/' . $fixture);
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors($errors);
-        $this->set_warnings($warnings);
+        $this->setErrors($errors);
+        $this->setWarnings($warnings);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/PHPUnitTestReturnTypeTest.php
+++ b/moodle/Tests/PHPUnitTestReturnTypeTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,28 +13,24 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test the PHPUnitTestReturnTypeSniff sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit\TestReturnTypeSniff
  */
-class PHPUnitTestReturnTypeTest extends MoodleCSBaseTestCase {
-
+class PHPUnitTestReturnTypeTest extends MoodleCSBaseTestCase
+{
     /**
-     * Data provider for self::provider_phpunit_data_returntypes
+     * Data provider for self::testPHPUnitTestReturnType
      */
-    public function provider_phpunit_data_returntypes(): array {
+    public function providerPHPUnitTestReturnType(): array {
         return [
             'Provider Casing' => [
                 'fixture' => 'fixtures/phpunit/TestReturnType/returntypes.php',
@@ -50,14 +47,14 @@ class PHPUnitTestReturnTypeTest extends MoodleCSBaseTestCase {
     }
 
     /**
-     * Test the moodle.PHPUnit.TestCaseCovers sniff
+     * Test the moodle.PHPUnit.TestReturnType sniff
      *
      * @param string $fixture relative path to fixture to use.
      * @param array $errors array of errors expected.
      * @param array $warnings array of warnings expected.
-     * @dataProvider provider_phpunit_data_returntypes
+     * @dataProvider providerPHPUnitTestReturnType
      */
-    public function test_phpunit_test_returntypes(
+    public function testPHPUnitTestReturnType(
         string $fixture,
         array $errors,
         array $warnings

--- a/moodle/Tests/Sniffs/Commenting/CategorySniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/CategorySniffTest.php
@@ -1,4 +1,5 @@
 <?php
+
 // This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
@@ -18,12 +19,9 @@ namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\Commenting;
 
 use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
 
-// phpcs:disable moodle.NamingConventions
-
 /**
  * Test the CategorySniff sniff.
  *
- * @category   test
  * @copyright  2024 onwards Andrew Lyons <andrew@nicols.co.uk>
  * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
@@ -34,7 +32,7 @@ class CategorySniffTest extends MoodleCSBaseTestCase
     /**
      * @dataProvider provider
      */
-    public function test_category_correctness(
+    public function testCategoryCorrectness(
         string $fixture,
         array $errors,
         array $warnings

--- a/moodle/Tests/Sniffs/Commenting/CategorySniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/CategorySniffTest.php
@@ -37,12 +37,12 @@ class CategorySniffTest extends MoodleCSBaseTestCase
         array $errors,
         array $warnings
     ): void {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Commenting.Category');
-        $this->set_fixture(sprintf("%s/fixtures/%s.php", __DIR__, $fixture));
-        $this->set_warnings($warnings);
-        $this->set_errors($errors);
-        $this->set_api_mapping([
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Commenting.Category');
+        $this->setFixture(sprintf("%s/fixtures/%s.php", __DIR__, $fixture));
+        $this->setWarnings($warnings);
+        $this->setErrors($errors);
+        $this->setApiMappings([
             'test' => [
                 'component' => 'core',
                 'allowspread' => true,
@@ -50,7 +50,7 @@ class CategorySniffTest extends MoodleCSBaseTestCase
             ],
         ]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     public static function provider(): array {

--- a/moodle/Tests/Sniffs/Commenting/InlineCommentSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/InlineCommentSniffTest.php
@@ -1,4 +1,5 @@
 <?php
+
 // This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
@@ -18,12 +19,9 @@ namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\Commenting;
 
 use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
 
-// phpcs:disable moodle.NamingConventions
-
 /**
  * Test the TestCaseNamesSniff sniff.
  *
- * @category   test
  * @copyright  2024 onwards Andrew Lyons <andrew@nicols.co.uk>
  * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *

--- a/moodle/Tests/Sniffs/Commenting/InlineCommentSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/InlineCommentSniffTest.php
@@ -31,9 +31,9 @@ class InlineCommentSniffTest extends MoodleCSBaseTestCase
 {
     public function testCommentBeforeAttribute(): void {
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Commenting.InlineComment');
-        $this->set_fixture(__DIR__ . '/../../fixtures/Commenting/InlineCommentAttributeAfter.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Commenting.InlineComment');
+        $this->setFixture(__DIR__ . '/../../fixtures/Commenting/InlineCommentAttributeAfter.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
@@ -41,10 +41,10 @@ class InlineCommentSniffTest extends MoodleCSBaseTestCase
         // - line => string of contents for message / source problem matching (only 1).
         $errors = [];
         $warnings = [];
-        $this->set_errors($errors);
-        $this->set_warnings($warnings);
+        $this->setErrors($errors);
+        $this->setWarnings($warnings);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/Sniffs/Commenting/PackageSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/PackageSniffTest.php
@@ -37,16 +37,16 @@ class PackageSniffTest extends MoodleCSBaseTestCase
         array $errors,
         array $warnings
     ): void {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Commenting.Package');
-        $this->set_fixture(sprintf("%s/fixtures/%s.php", __DIR__, $fixture));
-        $this->set_warnings($warnings);
-        $this->set_errors($errors);
-        $this->set_component_mapping([
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Commenting.Package');
+        $this->setFixture(sprintf("%s/fixtures/%s.php", __DIR__, $fixture));
+        $this->setWarnings($warnings);
+        $this->setErrors($errors);
+        $this->setComponentMapping([
             'local_codechecker' => dirname(__DIR__),
         ]);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     public static function packageCorrectnessProvider(): array {

--- a/moodle/Tests/Sniffs/Commenting/PackageSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/PackageSniffTest.php
@@ -1,4 +1,5 @@
 <?php
+
 // This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
@@ -18,12 +19,9 @@ namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\Commenting;
 
 use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
 
-// phpcs:disable moodle.NamingConventions
-
 /**
  * Test the TestCaseNamesSniff sniff.
  *
- * @category   test
  * @copyright  2024 onwards Andrew Lyons <andrew@nicols.co.uk>
  * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
@@ -31,11 +29,10 @@ use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
  */
 class PackageSniffTest extends MoodleCSBaseTestCase
 {
-
     /**
-     * @dataProvider package_correctness_provider
+     * @dataProvider packageCorrectnessProvider
      */
-    public function test_package_correctness(
+    public function testPackageCorrectness(
         string $fixture,
         array $errors,
         array $warnings
@@ -52,7 +49,7 @@ class PackageSniffTest extends MoodleCSBaseTestCase
         $this->verify_cs_results();
     }
 
-    public static function package_correctness_provider(): array {
+    public static function packageCorrectnessProvider(): array {
         return [
             'Standard fixes' => [
                 'fixture' => 'package_tags',
@@ -61,8 +58,8 @@ class PackageSniffTest extends MoodleCSBaseTestCase
                     31 => 'DocBlock missing a @package tag for class package_absent. Expected @package local_codechecker',
                     34 => 'Missing doc comment for function missing_docblock_in_function',
                     38 => 'Missing doc comment for class missing_docblock_in_class',
-                    42 => 'Incorrect @package tag for function package_wrong_in_function. Expected local_codechecker, found wrong_package.',
-                    48 => 'Incorrect @package tag for class package_wrong_in_class. Expected local_codechecker, found wrong_package.',
+                    42 => '@package tag for function package_wrong_in_function. Expected local_codechecker, found wrong_package.',
+                    48 => '@package tag for class package_wrong_in_class. Expected local_codechecker, found wrong_package.',
                     57 => 'More than one @package tag found in function package_multiple_in_function',
                     64 => 'More than one @package tag found in class package_multiple_in_class',
                     71 => 'More than one @package tag found in function package_multiple_in_function_all_wrong',
@@ -70,11 +67,11 @@ class PackageSniffTest extends MoodleCSBaseTestCase
                     85 => 'More than one @package tag found in interface package_multiple_in_interface_all_wrong',
                     92 => 'More than one @package tag found in trait package_multiple_in_trait_all_wrong',
                     95 => 'Missing doc comment for interface missing_docblock_interface',
-                    101 => 'DocBlock missing a @package tag for interface missing_package_interface. Expected @package local_codechecker',
-                    106 => 'Incorrect @package tag for interface incorrect_package_interface. Expected local_codechecker, found local_codecheckers.',
+                    101 => 'missing a @package tag for interface missing_package_interface. Expected @package',
+                    106 => '@package tag for interface incorrect_package_interface. Expected local_codechecker, found',
                     118 => 'Missing doc comment for trait missing_docblock_trait',
-                    124 => 'DocBlock missing a @package tag for trait missing_package_trait. Expected @package local_codechecker',
-                    129 => 'Incorrect @package tag for trait incorrect_package_trait. Expected local_codechecker, found local_codecheckers.',
+                    124 => 'DocBlock missing a @package tag for trait missing_package_trait. Expected @package',
+                    129 => 'Incorrect @package tag for trait incorrect_package_trait. Expected local_codechecker, found',
                 ],
                 'warnings' => [],
             ],

--- a/moodle/Tests/Sniffs/Commenting/TodoCommentSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/TodoCommentSniffTest.php
@@ -1,4 +1,5 @@
 <?php
+
 // This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
@@ -18,12 +19,9 @@ namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\Commenting;
 
 use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
 
-// phpcs:disable moodle.NamingConventions
-
 /**
  * Test the TestCaseNamesSniff sniff.
  *
- * @category   test
  * @copyright  2024 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
  * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *

--- a/moodle/Tests/Sniffs/Commenting/TodoCommentSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/TodoCommentSniffTest.php
@@ -31,9 +31,9 @@ class TodoCommentSniffTest extends MoodleCSBaseTestCase
 {
     public function testComentingTodoComment(): void {
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Commenting.TodoComment');
-        $this->set_fixture(__DIR__ . '/../../fixtures/Commenting/TodoComment.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Commenting.TodoComment');
+        $this->setFixture(__DIR__ . '/../../fixtures/Commenting/TodoComment.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
@@ -51,21 +51,21 @@ class TodoCommentSniffTest extends MoodleCSBaseTestCase
             33 => 'information in inline comment',
             34 => 'information in phpdoc comment',
         ];
-        $this->set_errors($errors);
-        $this->set_warnings($warnings);
+        $this->setErrors($errors);
+        $this->setWarnings($warnings);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     public function testEmptyConfigValue(): void {
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Commenting.TodoComment');
-        $this->set_fixture(__DIR__ . '/../../fixtures/Commenting/TodoCommentEmptyConfig.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Commenting.TodoComment');
+        $this->setFixture(__DIR__ . '/../../fixtures/Commenting/TodoCommentEmptyConfig.php');
 
         // Try with an empty config value.
-        $this->add_custom_config('moodleTodoCommentRegex', '');
+        $this->addCustomConfig('moodleTodoCommentRegex', '');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
@@ -73,21 +73,21 @@ class TodoCommentSniffTest extends MoodleCSBaseTestCase
         // - line => string of contents for message / source problem matching (only 1).
         $errors = [];
         $warnings = [];
-        $this->set_errors($errors);
-        $this->set_warnings($warnings);
+        $this->setErrors($errors);
+        $this->setWarnings($warnings);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     public function testCustomConfigValue(): void {
             // Define the standard, sniff and fixture to use.
-            $this->set_standard('moodle');
-            $this->set_sniff('moodle.Commenting.TodoComment');
-            $this->set_fixture(__DIR__ . '/../../fixtures/Commenting/TodoCommentCustomConfig.php');
+            $this->setStandard('moodle');
+            $this->setSniff('moodle.Commenting.TodoComment');
+            $this->setFixture(__DIR__ . '/../../fixtures/Commenting/TodoCommentCustomConfig.php');
 
             // Try with an empty config value.
-            $this->add_custom_config('moodleTodoCommentRegex', 'CUSTOM-[0-9]+');
+            $this->addCustomConfig('moodleTodoCommentRegex', 'CUSTOM-[0-9]+');
 
             // Define expected results (errors and warnings). Format, array of:
             // - line => number of problems,  or
@@ -98,10 +98,10 @@ class TodoCommentSniffTest extends MoodleCSBaseTestCase
                 8 => 'Missing required "CUSTOM-[0-9]+"',
                 9 => 'Missing required "CUSTOM-[0-9]+"',
             ];
-            $this->set_errors($errors);
-            $this->set_warnings($warnings);
+            $this->setErrors($errors);
+            $this->setWarnings($warnings);
 
             // Let's do all the hard work!
-            $this->verify_cs_results();
+            $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/Sniffs/Files/MoodleInternalTest.php
+++ b/moodle/Tests/Sniffs/Files/MoodleInternalTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,23 +13,20 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests\Files;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test the MoodleInternalSniff sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2013 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2013 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Files\MoodleInternalSniff
  */
-class MoodleInternalTest extends \MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase {
+class MoodleInternalTest extends \MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase
+{
     /**
      * @dataProvider provider
      */

--- a/moodle/Tests/Sniffs/Files/MoodleInternalTest.php
+++ b/moodle/Tests/Sniffs/Files/MoodleInternalTest.php
@@ -36,13 +36,13 @@ class MoodleInternalTest extends \MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTes
         array $errors
     ) {
         // Contains class_alias, which is not a side-effect.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Files.MoodleInternal');
-        $this->set_fixture(__DIR__ . '/fixtures/moodleinternal/' . $fixture . '.php');
-        $this->set_warnings($warnings);
-        $this->set_errors($errors);
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.MoodleInternal');
+        $this->setFixture(__DIR__ . '/fixtures/moodleinternal/' . $fixture . '.php');
+        $this->setWarnings($warnings);
+        $this->setErrors($errors);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 
     /**

--- a/moodle/Tests/Sniffs/Methods/MethodDeclarationSpacingSniffTest.php
+++ b/moodle/Tests/Sniffs/Methods/MethodDeclarationSpacingSniffTest.php
@@ -1,4 +1,5 @@
 <?php
+
 // This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
@@ -17,8 +18,6 @@
 namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\Methods;
 
 use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test the MethodDeclarationSpacing sniff.

--- a/moodle/Tests/Sniffs/Methods/MethodDeclarationSpacingSniffTest.php
+++ b/moodle/Tests/Sniffs/Methods/MethodDeclarationSpacingSniffTest.php
@@ -31,9 +31,9 @@ class MethodDeclarationSpacingSniffTest extends MoodleCSBaseTestCase
 {
     public function testMethodDeclarationSpacing(): void {
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Methods.MethodDeclarationSpacing');
-        $this->set_fixture(__DIR__ . '/../../fixtures/Methods/MethodDeclarationSpacing.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Methods.MethodDeclarationSpacing');
+        $this->setFixture(__DIR__ . '/../../fixtures/Methods/MethodDeclarationSpacing.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
@@ -56,10 +56,10 @@ class MethodDeclarationSpacingSniffTest extends MoodleCSBaseTestCase
             61 => 3,
         ];
         $warnings = [];
-        $this->set_errors($errors);
-        $this->set_warnings($warnings);
+        $this->setErrors($errors);
+        $this->setWarnings($warnings);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/Sniffs/Namespaces/NamespaceStatementSniffTest.php
+++ b/moodle/Tests/Sniffs/Namespaces/NamespaceStatementSniffTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,27 +13,23 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\Namespaces;
 
 use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
 
-// phpcs:disable moodle.NamingConventions
-
 /**
  * Test the NoLeadingSlash sniff.
  *
- * @package    moodle-cs
- * @category   test
  * @copyright  2023 Andrew Lyons <andrew@nicols.co.uk>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Namespaces\NamespaceStatementSniff
  */
 class NamespaceStatementSniffTest extends MoodleCSBaseTestCase
 {
-    public static function leading_slash_provider(): array
+    public static function leadingSlashProvider(): array
     {
         return [
             [
@@ -57,14 +54,13 @@ class NamespaceStatementSniffTest extends MoodleCSBaseTestCase
         ];
     }
     /**
-     * @dataProvider leading_slash_provider
+     * @dataProvider leadingSlashProvider
      */
-    public function test_leading_slash(
+    public function testLeadingSlash(
         string $fixture,
         array $warnings,
         array $errors
-    ): void
-    {
+    ): void {
         $this->set_standard('moodle');
         $this->set_sniff('moodle.Namespaces.NamespaceStatement');
         $this->set_fixture(sprintf("%s/fixtures/%s.php", __DIR__, $fixture));

--- a/moodle/Tests/Sniffs/Namespaces/NamespaceStatementSniffTest.php
+++ b/moodle/Tests/Sniffs/Namespaces/NamespaceStatementSniffTest.php
@@ -61,12 +61,12 @@ class NamespaceStatementSniffTest extends MoodleCSBaseTestCase
         array $warnings,
         array $errors
     ): void {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.Namespaces.NamespaceStatement');
-        $this->set_fixture(sprintf("%s/fixtures/%s.php", __DIR__, $fixture));
-        $this->set_warnings($warnings);
-        $this->set_errors($errors);
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Namespaces.NamespaceStatement');
+        $this->setFixture(sprintf("%s/fixtures/%s.php", __DIR__, $fixture));
+        $this->setWarnings($warnings);
+        $this->setErrors($errors);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/Sniffs/PHPUnit/TestCasesAbstractSniffTest.php
+++ b/moodle/Tests/Sniffs/PHPUnit/TestCasesAbstractSniffTest.php
@@ -53,12 +53,12 @@ class TestCasesAbstractSniffTest extends MoodleCSBaseTestCase
         array $errors,
         array $warnings
     ): void {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.PHPUnit.TestCasesAbstract');
-        $this->set_fixture(sprintf("%s/fixtures/%s.php", __DIR__, $fixture));
-        $this->set_warnings($warnings);
-        $this->set_errors($errors);
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHPUnit.TestCasesAbstract');
+        $this->setFixture(sprintf("%s/fixtures/%s.php", __DIR__, $fixture));
+        $this->setWarnings($warnings);
+        $this->setErrors($errors);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/Sniffs/PHPUnit/TestCasesAbstractSniffTest.php
+++ b/moodle/Tests/Sniffs/PHPUnit/TestCasesAbstractSniffTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,11 +13,9 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
-
-// phpcs:disable moodle.NamingConventions
 
 use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
 
@@ -24,16 +23,16 @@ use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
  * Test the TestCasesAbstractSniff sniff.
  *
  * @copyright  2024 Andrew Lyons <andrew@nicols.co.uk>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit\TestCasesAbstractSniff
  */
-class TestCasesAbstractSniffTest extends MoodleCSBaseTestCase {
-
+class TestCasesAbstractSniffTest extends MoodleCSBaseTestCase
+{
     /**
-     * Data provider for self::provider_phpunit_data_returntypes
+     * Data provider for self::testPHPUnitTestCasesAbstract
      */
-    public static function phpunit_classes_final_provider(): array {
+    public static function phpunitTestCasesAbstractProvider(): array {
         return [
             'Standard fixes' => [
                 'fixture' => 'testcaseclassesabstract',
@@ -47,9 +46,9 @@ class TestCasesAbstractSniffTest extends MoodleCSBaseTestCase {
     }
 
     /**
-     * @dataProvider phpunit_classes_final_provider
+     * @dataProvider phpunitTestCasesAbstractProvider
      */
-    public function test_phpunit_classes_final(
+    public function testPHPUnitTestCasesAbstract(
         string $fixture,
         array $errors,
         array $warnings

--- a/moodle/Tests/Sniffs/PHPUnit/TestClassesFinalSniffTest.php
+++ b/moodle/Tests/Sniffs/PHPUnit/TestClassesFinalSniffTest.php
@@ -55,12 +55,12 @@ class TestclassesFinalSniffTest extends MoodleCSBaseTestCase
         array $errors,
         array $warnings
     ): void {
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.PHPUnit.TestClassesFinal');
-        $this->set_fixture(sprintf("%s/fixtures/%s.php", __DIR__, $fixture));
-        $this->set_warnings($warnings);
-        $this->set_errors($errors);
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHPUnit.TestClassesFinal');
+        $this->setFixture(sprintf("%s/fixtures/%s.php", __DIR__, $fixture));
+        $this->setWarnings($warnings);
+        $this->setErrors($errors);
 
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/Sniffs/PHPUnit/TestClassesFinalSniffTest.php
+++ b/moodle/Tests/Sniffs/PHPUnit/TestClassesFinalSniffTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,11 +13,9 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
-
-// phpcs:disable moodle.NamingConventions
 
 use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
 
@@ -24,34 +23,34 @@ use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
  * Test the TestClassesFinalSniff sniff.
  *
  * @copyright  2024 Andrew Lyons <andrew@nicols.co.uk>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHPUnit\TestClassesFinalSniff
  */
-class TestclassesFinalSniffTest extends MoodleCSBaseTestCase {
-
+class TestclassesFinalSniffTest extends MoodleCSBaseTestCase
+{
     /**
-     * Data provider for self::provider_phpunit_data_returntypes
+     * Data provider for self::testPHPUnitClassesFinal
      */
-    public static function phpunit_classes_final_provider(): array {
+    public static function phpunitClassesFinalProvider(): array {
         return [
             'Standard fixes' => [
                 'fixture' => 'testclassesfinal',
                 'errors' => [
                 ],
                 'warnings' => [
-                    15 => 'Unit test example_abstract_test_with_abstract_children_test should be declared as final and not abstract.',
-                    19 => 'Unit test example_abstract_test should be declared as final and not abstract.',
-                    23 => 'Unit test example_standard_test should be declared as final.',
+                    15 => 'example_abstract_test_with_abstract_children_test should be declared as final and not abstract.',
+                    19 => 'example_abstract_test should be declared as final and not abstract.',
+                    23 => 'example_standard_test should be declared as final.',
                 ],
             ],
         ];
     }
 
     /**
-     * @dataProvider phpunit_classes_final_provider
+     * @dataProvider phpunitClassesFinalProvider
      */
-    public function test_phpunit_classes_final(
+    public function testPHPUnitClassesFinal(
         string $fixture,
         array $errors,
         array $warnings

--- a/moodle/Tests/SquizArraysArrayBrackerSpacingTest.php
+++ b/moodle/Tests/SquizArraysArrayBrackerSpacingTest.php
@@ -33,15 +33,15 @@ class SquizArraysArrayBrackerSpacingTest extends MoodleCSBaseTestCase
     public function testSquizArrayaArrayBracketSpacing() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('Squiz.Arrays.ArrayBracketSpacing');
-        $this->set_fixture(__DIR__ . '/fixtures/squiz_arrays_arraybracketspacing.php');
+        $this->setStandard('moodle');
+        $this->setSniff('Squiz.Arrays.ArrayBracketSpacing');
+        $this->setFixture(__DIR__ . '/fixtures/squiz_arrays_arraybracketspacing.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             4 => "expected \"\$arr[\" but found \"\$arr [\"",
             5 => ["expected \"['wrong'\" but found \"[ 'wrong'\"", "expected \"'wrong']\" but found \"'wrong' ]\""],
             17 => 3,
@@ -51,9 +51,9 @@ class SquizArraysArrayBrackerSpacingTest extends MoodleCSBaseTestCase
             31 => 2,
             34 => 2,
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/SquizArraysArrayBrackerSpacingTest.php
+++ b/moodle/Tests/SquizArraysArrayBrackerSpacingTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,28 +13,24 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test the PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayBracketSpacingSniff sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayBracketSpacingSniff
  */
-class SquizArraysArrayBrackerSpacingTest extends MoodleCSBaseTestCase {
-
+class SquizArraysArrayBrackerSpacingTest extends MoodleCSBaseTestCase
+{
     /**
      * Test the Squid.Arrays.ArrayBracketSpacing sniff
      */
-    public function test_squiz_arrays_arraybracketspacing() {
+    public function testSquizArrayaArrayBracketSpacing() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');

--- a/moodle/Tests/SquizOperatorsValidLogicalOperatorsTest.php
+++ b/moodle/Tests/SquizOperatorsValidLogicalOperatorsTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,28 +13,24 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test the PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\ValidLogicalOperatorsSniff sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2022 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \PHP_CodeSniffer\Standards\Squiz\Sniffs\Operators\ValidLogicalOperatorsSniff
  */
-class SquizOperatorsValidLogicalOperatorsTest extends MoodleCSBaseTestCase {
-
+class SquizOperatorsValidLogicalOperatorsTest extends MoodleCSBaseTestCase
+{
     /**
-     * Test the Squid.Arrays.ValidLogicalOperators sniff
+     * Test the Squid.Operators.ValidLogicalOperators sniff
      */
-    public function test_squiz_operators_validlogicaloperators() {
+    public function testSquizOperatorsValidLogicalOperators() {
 
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');

--- a/moodle/Tests/SquizOperatorsValidLogicalOperatorsTest.php
+++ b/moodle/Tests/SquizOperatorsValidLogicalOperatorsTest.php
@@ -33,23 +33,23 @@ class SquizOperatorsValidLogicalOperatorsTest extends MoodleCSBaseTestCase
     public function testSquizOperatorsValidLogicalOperators() {
 
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('Squiz.Operators.ValidLogicalOperators');
-        $this->set_fixture(__DIR__ . '/fixtures/squiz_operators_validlogicaloperators.php');
+        $this->setStandard('moodle');
+        $this->setSniff('Squiz.Operators.ValidLogicalOperators');
+        $this->setFixture(__DIR__ . '/fixtures/squiz_operators_validlogicaloperators.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             21 => 'Logical operator "or" is prohibited; use "||" instead',
             25 => 'Squiz.Operators.ValidLogicalOperators.NotAllowed',
             29 => 2,
             33 => 4,
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/Util/DocblocksTest.php
+++ b/moodle/Tests/Util/DocblocksTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,7 +13,7 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests\Util;
 
@@ -21,19 +22,16 @@ use MoodleHQ\MoodleCS\moodle\Util\Docblocks;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Ruleset;
 
-// phpcs:disable moodle.NamingConventions
-
 /**
  * Test the Docblocks specific moodle utilities class
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Util\Docblocks
  */
-class DocblocksTest extends MoodleCSBaseTestCase {
+class DocblocksTest extends MoodleCSBaseTestCase
+{
     public function testGetDocBlock(): void {
         $phpcsConfig = new Config();
         $phpcsRuleset = new Ruleset($phpcsConfig);

--- a/moodle/Tests/Util/MoodleUtilTest.php
+++ b/moodle/Tests/Util/MoodleUtilTest.php
@@ -941,7 +941,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase
             $vfs
         );
 
-        $this->set_api_mapping($apis);
+        $this->setApiMappings($apis);
 
         // We are passing a real File, prepare it.
         $phpcsConfig = new Config();

--- a/moodle/Tests/Util/MoodleUtilTest.php
+++ b/moodle/Tests/Util/MoodleUtilTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,7 +13,7 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests\Util;
 
@@ -25,20 +26,16 @@ use PHP_CodeSniffer\Ruleset;
 use org\bovigo\vfs\vfsStream;
 use PHPCSUtils\Utils\ObjectDeclarations;
 
-// phpcs:disable moodle.NamingConventions
-
 /**
  * Test the MoodleUtil specific moodle utilities class
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Util\MoodleUtil
  */
-class MoodleUtilTest extends MoodleCSBaseTestCase {
-
+class MoodleUtilTest extends MoodleCSBaseTestCase
+{
     /**
      * Unit test for calculateAllComponents.
      *
@@ -46,21 +43,21 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
      * and it's already indirectly tested by {@see test_getMoodleComponent()}
      * but it has some feature that we need to test individually here.
      */
-    public function test_calculateAllComponents() {
+    public function testCalculateAllComponents() {
         // Let's calculate moodleRoot.
         $vfs = vfsStream::setup('root', null, []);
         $moodleRoot = $vfs->url();
 
         // Let's prepare a components file, with some correct and incorrect entries.
         $components =
-            "nonono,mod_forum,{$moodleRoot}/mod_forum\n" .                // Wrong type.
-            "plugin,mod__nono,{$moodleRoot}/mod_forum\n" .                // Wrong component.
-            "plugin,mod_forum,/no/no/no/no//mod_forum\n" .                // Wrong path.
-            "plugin,local_codechecker,{$moodleRoot}/local/codechecker\n" .// All ok.
-            "plugin,mod_forum,{$moodleRoot}/mod/forum\n";                 // All ok.
+            "nonono,mod_forum,{$moodleRoot}/mod_forum\n" .                 // Wrong type.
+            "plugin,mod__nono,{$moodleRoot}/mod_forum\n" .                 // Wrong component.
+            "plugin,mod_forum,/no/no/no/no//mod_forum\n" .                 // Wrong path.
+            "plugin,local_codechecker,{$moodleRoot}/local/codechecker\n" . // All ok.
+            "plugin,mod_forum,{$moodleRoot}/mod/forum\n";                  // All ok.
 
         vfsStream::create(
-            ['components.txt' => $components,],
+            ['components.txt' => $components],
             $vfs
         );
 
@@ -78,10 +75,16 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
         $loadedComponents = $property->getValue();
 
         $this->assertCount(2, $loadedComponents);
-        $this->assertSame(['mod_forum', 'local_codechecker'],
-            array_keys($loadedComponents)); // Verify they are ordered in ascending order.
-        $this->assertSame(["{$moodleRoot}/mod/forum", "{$moodleRoot}/local/codechecker"],
-            array_values($loadedComponents)); // Verify component paths are also the expected ones.
+        // Verify they are ordered in ascending order.
+        $this->assertSame(
+            ['mod_forum', 'local_codechecker'],
+            array_keys($loadedComponents)
+        );
+        // Verify component paths are also the expected ones.
+        $this->assertSame(
+            ["{$moodleRoot}/mod/forum", "{$moodleRoot}/local/codechecker"],
+            array_values($loadedComponents)
+        );
 
         // Now be evil and try with an unreadable file, it must throw an exception.
 
@@ -162,7 +165,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
      *
      * @dataProvider getMoodleComponentProvider
      */
-    public function test_getMoodleComponent(
+    public function testGetMoodleComponent(
         array $config,
         array $return,
         bool $reset = true,
@@ -205,8 +208,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
                 $this->assertInstanceOf($return['exception'], $e);
                 $this->assertStringContainsString($return['message'], $e->getMessage());
             }
-
-        } else if (array_key_exists('value', $return)) {
+        } elseif (array_key_exists('value', $return)) {
             // Normal asserting result.
             $this->assertSame($return['value'], MoodleUtil::getMoodleComponent($file, $selfPath));
         }
@@ -276,7 +278,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
      *
      * @dataProvider getMoodleBranchProvider
      */
-    public function test_getMoodleBranch(array $config, array $return, bool $reset = true, bool $selfPath = true) {
+    public function testGetMoodleBranch(array $config, array $return, bool $reset = true, bool $selfPath = true) {
         $file = null;
         // Set config options when passed.
         if ($config) {
@@ -301,8 +303,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
                 $this->assertInstanceOf($return['exception'], $e);
                 $this->assertStringContainsString($return['message'], $e->getMessage());
             }
-
-        } else if (array_key_exists('value', $return)) {
+        } elseif (array_key_exists('value', $return)) {
             // Normal asserting result.
             $this->assertSame($return['value'], MoodleUtil::getMoodleBranch($file, $selfPath));
         }
@@ -385,7 +386,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
      *
      * @dataProvider getMoodleRootProvider
      */
-    public function test_getMoodleRoot(
+    public function testGetMoodleRoot(
         array $config,
         array $return,
         bool $requireMockMoodle = false,
@@ -433,8 +434,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
                 $this->assertInstanceOf($return['exception'], $e);
                 $this->assertStringContainsString($return['message'], $e->getMessage());
             }
-
-        } else if (array_key_exists('value', $return)) {
+        } elseif (array_key_exists('value', $return)) {
             // Normal asserting result.
             $this->assertSame($return['value'], MoodleUtil::getMoodleRoot($file), $selfPath);
         }
@@ -533,8 +533,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
     public function testIsUnitTest(
         string $filepath,
         bool $expected
-    ): void
-    {
+    ): void {
         $phpcsConfig = new Config();
         $phpcsRuleset = new Ruleset($phpcsConfig);
         $file = new File($filepath, $phpcsRuleset, $phpcsConfig);
@@ -589,8 +588,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
         string $filepath,
         string $testClassName,
         bool $expected
-    ): void
-    {
+    ): void {
         $phpcsConfig = new Config();
         $phpcsRuleset = new Ruleset($phpcsConfig);
 
@@ -655,15 +653,14 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
     /**
      * @dataProvider meetsMinimumMoodleVersionProvider
      * @param string|int $moodleVersion
-     * @param int $minversion
+     * @param int $minVersion
      * @param array $return
      */
     public function testMeetsMinimumMoodleVersion(
         $moodleVersion,
         int $minVersion,
         array $return
-    ): void
-    {
+    ): void {
         Config::setConfigData('moodleBranch', $moodleVersion, true);
 
         $phpcsConfig = new Config();
@@ -678,7 +675,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
                 $this->assertInstanceOf($return['exception'], $e);
                 $this->assertStringContainsString($return['message'], $e->getMessage());
             }
-        } else if (array_key_exists('value', $return)) {
+        } elseif (array_key_exists('value', $return)) {
             // Normal asserting result.
             $this->assertSame($return['value'], MoodleUtil::meetsMinimumMoodleVersion($file, $minVersion));
         }
@@ -730,8 +727,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
     public function testFindClassMethodPointer(
         string $methodName,
         bool $found
-    ): void
-    {
+    ): void {
         $phpcsConfig = new Config();
         $phpcsRuleset = new Ruleset($phpcsConfig);
         $phpcsFile = new \PHP_CodeSniffer\Files\LocalFile(
@@ -756,8 +752,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
         }
     }
 
-    public function testGetTokensOnLine(): void
-    {
+    public function testGetTokensOnLine(): void {
         $phpcsConfig = new Config();
         $phpcsRuleset = new Ruleset($phpcsConfig);
         $phpcsFile = new \PHP_CodeSniffer\Files\LocalFile(
@@ -809,7 +804,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
                         $apis,
                         JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
                     ),
-                    'example.php' => ''
+                    'example.php' => '',
                 ],
             ],
             $vfs
@@ -856,7 +851,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
             [
                 'lib' => [
                     'apis.json' => 'invalid:"json"',
-                    'example.php' => ''
+                    'example.php' => '',
                 ],
             ],
             $vfs
@@ -901,7 +896,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
                         $apis,
                         JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
                     ),
-                    'example.php' => ''
+                    'example.php' => '',
                 ],
             ],
             $vfs
@@ -940,7 +935,7 @@ class MoodleUtilTest extends MoodleCSBaseTestCase {
             [
                 'lib' => [
                     'apis.json' => json_encode([]),
-                    'example.php' => ''
+                    'example.php' => '',
                 ],
             ],
             $vfs

--- a/moodle/Tests/WhiteSpaceSpaceAfterCommaTest.php
+++ b/moodle/Tests/WhiteSpaceSpaceAfterCommaTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,25 +13,21 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test the SpaceAfterComma sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\WhiteSpace\SpaceAfterCommaSniff
  */
-class WhiteSpaceSpaceAfterCommaTest extends MoodleCSBaseTestCase {
-
-    public function test_whitespace_spaceaftercomma() {
+class WhiteSpaceSpaceAfterCommaTest extends MoodleCSBaseTestCase
+{
+    public function testWhitespaceSpaceAfterComma() {
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
         $this->set_sniff('moodle.WhiteSpace.SpaceAfterComma');

--- a/moodle/Tests/WhiteSpaceSpaceAfterCommaTest.php
+++ b/moodle/Tests/WhiteSpaceSpaceAfterCommaTest.php
@@ -29,20 +29,20 @@ class WhiteSpaceSpaceAfterCommaTest extends MoodleCSBaseTestCase
 {
     public function testWhitespaceSpaceAfterComma() {
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.WhiteSpace.SpaceAfterComma');
-        $this->set_fixture(__DIR__ . '/fixtures/whitespace/spaceaftercomma.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.WhiteSpace.SpaceAfterComma');
+        $this->setFixture(__DIR__ . '/fixtures/whitespace/spaceaftercomma.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             5 => 2,
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/WhiteSpaceWhiteSpaceInStringsTest.php
+++ b/moodle/Tests/WhiteSpaceWhiteSpaceInStringsTest.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,25 +13,21 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Tests;
-
-// phpcs:disable moodle.NamingConventions
 
 /**
  * Test the WhiteSpaceInStrings sniff.
  *
- * @package    local_codechecker
- * @category   test
- * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\WhiteSpace\WhiteSpaceInStringsSniff
  */
-class WhiteSpaceWhiteSpaceInStringsTest extends MoodleCSBaseTestCase {
-
-    public function test_whitespace_whitespaceinstrings() {
+class WhiteSpaceWhiteSpaceInStringsTest extends MoodleCSBaseTestCase
+{
+    public function testWhiteSpaceWhiteSpaceInStrings() {
         // Define the standard, sniff and fixture to use.
         $this->set_standard('moodle');
         $this->set_sniff('moodle.WhiteSpace.WhiteSpaceInStrings');

--- a/moodle/Tests/WhiteSpaceWhiteSpaceInStringsTest.php
+++ b/moodle/Tests/WhiteSpaceWhiteSpaceInStringsTest.php
@@ -29,21 +29,21 @@ class WhiteSpaceWhiteSpaceInStringsTest extends MoodleCSBaseTestCase
 {
     public function testWhiteSpaceWhiteSpaceInStrings() {
         // Define the standard, sniff and fixture to use.
-        $this->set_standard('moodle');
-        $this->set_sniff('moodle.WhiteSpace.WhiteSpaceInStrings');
-        $this->set_fixture(__DIR__ . '/fixtures/whitespace/whitespaceinstrings.php');
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.WhiteSpace.WhiteSpaceInStrings');
+        $this->setFixture(__DIR__ . '/fixtures/whitespace/whitespaceinstrings.php');
 
         // Define expected results (errors and warnings). Format, array of:
         // - line => number of problems,  or
         // - line => array of contents for message / source problem matching.
         // - line => string of contents for message / source problem matching (only 1).
-        $this->set_errors([
+        $this->setErrors([
             5 => '@Message: Whitespace found at end of line within string',
             7 => '@Message: Tab found within whitespace',
         ]);
-        $this->set_warnings([]);
+        $this->setWarnings([]);
 
         // Let's do all the hard work!
-        $this->verify_cs_results();
+        $this->verifyCsResults();
     }
 }

--- a/moodle/Tests/bootstrap.php
+++ b/moodle/Tests/bootstrap.php
@@ -1,12 +1,12 @@
-<?php
+<?php  //phpcs:ignore PSR1.Files.SideEffects
+
 /**
  * Moodle Coding Standards.
  *
  * Bootstrap file for running PHPUnit tests.
  *
- * @package   MoodleHQ\MoodleCS\moodle
  * @link      https://github.com/moodlehq/moodle-cs
- * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @copyright Andrew Lyons <andrew@nicols.co.uk>
  */
 

--- a/moodle/Util/Docblocks.php
+++ b/moodle/Util/Docblocks.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,7 +13,7 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Util;
 
@@ -22,16 +23,14 @@ use PHP_CodeSniffer\Files\DummyFile;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Ruleset;
 
-// phpcs:disable moodle.NamingConventions
-
 /**
  * Utilities related to PHP DocBlocks.
  *
- * @package    local_codechecker
  * @copyright  2024 Andrew Lyons <andrew@nicols.co.uk>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-abstract class Docblocks {
+abstract class Docblocks
+{
     /**
      * Get the docblock for a file, class, interface, trait, or method.
      *
@@ -56,9 +55,9 @@ abstract class Docblocks {
         ];
         if ($token['code'] === T_DOC_COMMENT_OPEN_TAG) {
             return $token;
-        } else if ($token['code'] === T_DOC_COMMENT_CLOSE_TAG) {
+        } elseif ($token['code'] === T_DOC_COMMENT_CLOSE_TAG) {
             return $tokens[$token['comment_opener']];
-        } else if (in_array($token['code'], $midDocBlockTokens)) {
+        } elseif (in_array($token['code'], $midDocBlockTokens)) {
             $commentStart = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr);
             return $commentStart ? $tokens[$commentStart] : null;
         }

--- a/moodle/Util/MoodleUtil.php
+++ b/moodle/Util/MoodleUtil.php
@@ -1,5 +1,6 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,7 +13,7 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 namespace MoodleHQ\MoodleCS\moodle\Util;
 
@@ -22,17 +23,14 @@ use PHP_CodeSniffer\Files\DummyFile;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Ruleset;
 
-// phpcs:disable moodle.NamingConventions
-
 /**
  * Various utility methods specific to Moodle stuff.
  *
- * @package    local_codechecker
- * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link http://stronk7.com}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-abstract class MoodleUtil {
-
+abstract class MoodleUtil
+{
     /**
      * @var string Absolute path, cached, containing moodle root detected directory.
      */
@@ -139,7 +137,9 @@ abstract class MoodleUtil {
         if ($componentsFile = Config::getConfigData('moodleComponentsListPath')) {
             if (!is_readable($componentsFile)) {
                 throw new DeepExitException(
-                    "ERROR: Incorrect 'moodleComponentsListPath' config/runtime option. File not found: '$componentsFile'", 3);
+                    "ERROR: Incorrect 'moodleComponentsListPath' config/runtime option. File not found: '$componentsFile'",
+                    3
+                );
             }
             // Go processing the file.
             $handle = fopen($componentsFile, "r");
@@ -328,11 +328,15 @@ abstract class MoodleUtil {
             // Verify it's integer value and <= 9999 (4 digits max).
             if (filter_var($branch, FILTER_VALIDATE_INT) === false) {
                 throw new DeepExitException(
-                    "ERROR: Incorrect 'moodleBranch' config/runtime option. Value in not an integer: '$branch'", 3);
+                    "ERROR: Incorrect 'moodleBranch' config/runtime option. Value in not an integer: '$branch'",
+                    3
+                );
             }
             if ($branch > 9999) {
                 throw new DeepExitException(
-                    "ERROR: Incorrect 'moodleBranch' config/runtime option. Value must be 4 digit max.: '$branch'", 3);
+                    "ERROR: Incorrect 'moodleBranch' config/runtime option. Value must be 4 digit max.: '$branch'",
+                    3
+                );
             }
             self::$moodleBranch = $branch;
             return self::$moodleBranch;
@@ -388,12 +392,16 @@ abstract class MoodleUtil {
             // Verify the path is exists and is readable.
             if (!is_dir($path) || !is_readable($path)) {
                 throw new DeepExitException(
-                    "ERROR: Incorrect 'moodleRoot' config/runtime option. Directory does not exist or is not readable: '$path'", 3);
+                    "ERROR: Incorrect 'moodleRoot' config/runtime option. Directory does not exist or is not readable: '$path'",
+                    3
+                );
             }
             // Verify the path has version.php and config-dist.php files. Very basic, but effective check.
             if (!is_readable($path . '/version.php') || !is_readable($path . '/config-dist.php')) {
                 throw new DeepExitException(
-                    "ERROR: Incorrect 'moodleRoot' config/runtime option. Directory is not a valid moodle root: '$path'", 3);
+                    "ERROR: Incorrect 'moodleRoot' config/runtime option. Directory is not a valid moodle root: '$path'",
+                    3
+                );
             }
             self::$moodleRoot = $path;
             return self::$moodleRoot;
@@ -441,8 +449,8 @@ abstract class MoodleUtil {
      *
      * Any file which is not correctly named will be ignored.
      *
-     * @param File $phpcsFile 
-     * @return bool 
+     * @param File $phpcsFile
+     * @return bool
      */
     public static function isUnitTest(File $phpcsFile): bool
     {
@@ -527,8 +535,7 @@ abstract class MoodleUtil {
     public static function meetsMinimumMoodleVersion(
         File $phpcsFile,
         int $version
-    ): ?bool
-    {
+    ): ?bool {
         $moodleBranch = self::getMoodleBranch($phpcsFile);
         if (!isset($moodleBranch)) {
             // We cannot determine the moodle branch, so we cannot determine if the version is met.
@@ -550,8 +557,7 @@ abstract class MoodleUtil {
         File $phpcsFile,
         int $classPtr,
         string $methodName
-    ): ?int
-    {
+    ): ?int {
         $mStart = $classPtr;
         $tokens = $phpcsFile->getTokens();
         while ($mStart = $phpcsFile->findNext(T_FUNCTION, $mStart + 1, $tokens[$classPtr]['scope_closer'])) {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset>
+    <description>The coding rules configuration for the moodle-cs project.</description>
+
+    <!-- We don't want to analyse these -->
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/Tests/fixtures/*</exclude-pattern>
+    <exclude-pattern>*/Tests/*/fixtures/*</exclude-pattern>
+
+    <!-- PSR12 with a few exceptions and adjustments -->
+    <rule ref="PSR12">
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine"/>
+    </rule>
+
+    <!-- Some more chars don't hurt too much -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="132"/>
+            <property name="absoluteLineLimit" value="180"/>
+        </properties>
+    </rule>
+
+    <!-- We want to enforce && and || instead of and and or -->
+    <rule ref="Squiz.Operators.ValidLogicalOperators"/>
+
+    <!-- We want to use always the short array syntax -->
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
+    <!-- We want better commas managing -->
+    <!-- Space after comma -->
+    <rule ref="moodle.WhiteSpace.SpaceAfterComma"/>
+    <!-- Comma at the end of multi-line arrays -->
+    <rule ref="NormalizedArrays.Arrays.CommaAfterLast">
+        <exclude name="NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine" />
+    </rule>
+
+    <!--PHPCompatibility configuration-->
+    <rule ref="./vendor/phpcompatibility/php-compatibility/PHPCompatibility/ruleset.xml"/>
+    <config name="testVersion" value="7.4-"/>
+
+    <!-- These are false positives because CodeSniffer creates them when needed.
+        TODO: Delete this once we raise minimum requirements to PHP 8.0. -->
+    <rule ref="PHPCompatibility.Constants.NewConstants">
+        <exclude name="PHPCompatibility.Constants.NewConstants.newConstants.t_enumFound"/>
+    </rule>
+</ruleset>


### PR DESCRIPTION
Here we are introducing the phpcs.xml.dist file that will guide our coding style within moodle-cs.

- It scans all the code but vendor and fixtures directories.
- It's the complete PSR12 standard but allowing single-line function declarations to have the opening curly bracket in the same line.
- With line length adjusted to 132 / 180.
- And a few more sniffs, not part of the PSR12, but good for readability (hopefully non-controversial):
  - && and || logical operators.
  - Short array syntax.
  - Space after commas.
  - Comma at the end of multi-line arrays.
  - PHPCompatibility standard to check for >=7.4 (with an exception about T_ENUM false positives).

And that's it!

Then, apart of the above, small adjustments to the composer.json and .gitignore files.