### PR TITLE
Add sniff to detect missing docblocks

### DIFF
--- a/moodle/Sniffs/Commenting/MissingDocblockSniff.php
+++ b/moodle/Sniffs/Commenting/MissingDocblockSniff.php
@@ -1,0 +1,190 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANdTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Sniffs\Commenting;
+
+use MoodleHQ\MoodleCS\moodle\Util\Docblocks;
+use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
+use MoodleHQ\MoodleCS\moodle\Util\TokenUtil;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Checks that all files an classes have appropriate docs.
+ *
+ * @copyright  2024 Andrew Lyons <andrew@nicols.co.uk>
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class MissingDocblockSniff implements Sniff
+{
+    /** @var array A list of standard method names used in unit test files */
+    protected array $phpunitStandardMethodNames = [
+        'setUp',
+        'tearDown',
+        'setUpBeforeClass',
+        'tearDownAfterClass',
+    ];
+
+    /**
+     * Register for open tag (only process once per file).
+     */
+    public function register() {
+        return [
+            T_OPEN_TAG,
+        ];
+    }
+
+    /**
+     * Processes php files and perform various checks with file.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The position in the stack.
+     */
+    public function process(File $phpcsFile, $stackPtr) {
+        $this->processScopes($phpcsFile, $stackPtr);
+        $this->processFunctions($phpcsFile, $stackPtr);
+    }
+
+    protected function processScopes(File $phpcsFile, int $stackPtr): void {
+        $tokens = $phpcsFile->getTokens();
+
+        // Each class, interface, trait, and enum must have a docblock.
+        // If a file has one class, interface, trait, or enum, the file docblock is optional.
+        // Otherwise, the file docblock is required.
+
+        $artifactCount = 0;
+        $missingDocblocks = [];
+        $find = Tokens::$ooScopeTokens;
+        $find[] = T_FUNCTION;
+
+        $typePtr = $stackPtr + 1;
+        while ($typePtr = $phpcsFile->findNext($find, $typePtr + 1)) {
+            $token = $tokens[$typePtr];
+            if ($token['code'] === T_FUNCTION && !empty($token['conditions'])) {
+                // Skip methods of classes, traits and interfaces.
+                continue;
+            }
+            $artifactCount++;
+
+            if ($token['code'] === T_FUNCTION) {
+                // Skip functions. They are handled separately.
+                continue;
+            }
+
+            if (!Docblocks::getDocBlock($phpcsFile, $typePtr)) {
+                $missingDocblocks[] = $typePtr;
+            }
+        }
+
+        if ($artifactCount !== 1) {
+            // See if there is a file docblock.
+            $fileblock = Docblocks::getDocBlock($phpcsFile, $stackPtr);
+
+            if ($fileblock === null) {
+                $objectName = TokenUtil::getObjectName($phpcsFile, $stackPtr);
+                $phpcsFile->addError('Missing docblock for file %s', $stackPtr, 'Missing', [$objectName]);
+            }
+        }
+
+        foreach ($missingDocblocks as $typePtr) {
+            $token = $tokens[$typePtr];
+            $objectName = TokenUtil::getObjectName($phpcsFile, $typePtr);
+            $objectType = TokenUtil::getObjectType($phpcsFile, $typePtr);
+
+            $phpcsFile->addError('Missing docblock for %s %s', $typePtr, 'Missing', [$objectType, $objectName]);
+        }
+
+        if ($artifactCount === 1) {
+            // Only one artifact.
+            // No need for file docblock.
+            return;
+        }
+    }
+
+    /**
+     * Process functions.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The position in the stack.
+     */
+    protected function processFunctions(File $phpcsFile, int $stackPtr): void {
+        // Missing docblocks for unit tests are treated as warnings.
+        $isUnitTestFile = MoodleUtil::isUnitTest($phpcsFile);
+
+        $tokens = $phpcsFile->getTokens();
+
+        $missingDocblocks = [];
+        $knownClasses = [];
+
+        $typePtr = $stackPtr + 1;
+        while ($typePtr = $phpcsFile->findNext(T_FUNCTION, $typePtr + 1)) {
+            $token = $tokens[$typePtr];
+            $extendsOrImplements = false;
+
+            if ($isUnitTestFile) {
+                if (in_array(TokenUtil::getObjectName($phpcsFile, $typePtr), $this->phpunitStandardMethodNames)) {
+                    // Skip standard PHPUnit methods.
+                    continue;
+                }
+            }
+
+            if (count($token['conditions']) > 0) {
+                // This method has conditions (a Class, Interface, Trait, etc.).
+                // Check if that container extends or implements anything.
+                foreach (array_keys($token['conditions']) as $condition) {
+                    if (!array_key_exists($condition, $knownClasses)) {
+                        $extendsOrImplements = $extendsOrImplements || ObjectDeclarations::findExtendedClassName(
+                            $phpcsFile,
+                            $condition
+                        );
+                        $extendsOrImplements = $extendsOrImplements || ObjectDeclarations::findImplementedInterfaceNames(
+                            $phpcsFile,
+                            $condition
+                        );
+                        $extendsOrImplements = $extendsOrImplements || ObjectDeclarations::findExtendedInterfaceNames(
+                            $phpcsFile,
+                            $condition
+                        );
+                        $knownClasses[$condition] = $extendsOrImplements;
+                    }
+                    $extendsOrImplements = $extendsOrImplements || $knownClasses[$condition];
+                    if ($extendsOrImplements) {
+                        break;
+                    }
+                }
+            }
+
+            if (!Docblocks::getDocBlock($phpcsFile, $typePtr)) {
+                $missingDocblocks[$typePtr] = $extendsOrImplements;
+            }
+        }
+
+        foreach ($missingDocblocks as $typePtr => $extendsOrImplements) {
+            $token = $tokens[$typePtr];
+            $objectName = TokenUtil::getObjectName($phpcsFile, $typePtr);
+            $objectType = TokenUtil::getObjectType($phpcsFile, $typePtr);
+
+            if ($extendsOrImplements) {
+                $phpcsFile->addWarning('Missing docblock for %s %s', $typePtr, 'Missing', [$objectType, $objectName]);
+            } else {
+                $phpcsFile->addError('Missing docblock for %s %s', $typePtr, 'Missing', [$objectType, $objectName]);
+            }
+        }
+    }
+}

--- a/moodle/Sniffs/Commenting/PackageSniff.php
+++ b/moodle/Sniffs/Commenting/PackageSniff.php
@@ -19,9 +19,9 @@ namespace MoodleHQ\MoodleCS\moodle\Sniffs\Commenting;
 
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 use MoodleHQ\MoodleCS\moodle\Util\Docblocks;
+use MoodleHQ\MoodleCS\moodle\Util\Tokens;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
-use PHPCSUtils\Utils\ObjectDeclarations;
 
 /**
  * Checks that all test classes and global functions have appropriate @package tags.
@@ -90,43 +90,6 @@ class PackageSniff implements Sniff
     }
 
     /**
-     * Get the human-readable object type.
-     *
-     * @param File $phpcsFile
-     * @param int $stackPtr
-     * @return string
-     */
-    protected function getObjectType(
-        File $phpcsFile,
-        int $stackPtr
-    ): string {
-        $tokens = $phpcsFile->getTokens();
-        if ($tokens[$stackPtr]['code'] === T_OPEN_TAG) {
-            return 'file';
-        }
-        return $tokens[$stackPtr]['content'];
-    }
-
-    /**
-     * Get the human readable object name.
-     *
-     * @param File $phpcsFile
-     * @param int $stackPtr
-     * @return string
-     */
-    protected function getObjectName(
-        File $phpcsFile,
-        int $stackPtr
-    ): string {
-        $tokens = $phpcsFile->getTokens();
-        if ($tokens[$stackPtr]['code'] === T_OPEN_TAG) {
-            return basename($phpcsFile->getFilename());
-        }
-
-        return ObjectDeclarations::getName($phpcsFile, $stackPtr);
-    }
-
-    /**
      * Check the docblock for a @package tag.
      *
      * @param File $phpcsFile
@@ -140,8 +103,8 @@ class PackageSniff implements Sniff
         array $docblock
     ): bool {
         $tokens = $phpcsFile->getTokens();
-        $objectName = $this->getObjectName($phpcsFile, $stackPtr);
-        $objectType = $this->getObjectType($phpcsFile, $stackPtr);
+        $objectName = Tokens::getObjectName($phpcsFile, $stackPtr);
+        $objectType = Tokens::getObjectType($phpcsFile, $stackPtr);
         $expectedPackage = MoodleUtil::getMoodleComponent($phpcsFile, true);
 
         // Nothing to do if we have been unable to determine the package

--- a/moodle/Sniffs/Commenting/PackageSniff.php
+++ b/moodle/Sniffs/Commenting/PackageSniff.php
@@ -19,7 +19,7 @@ namespace MoodleHQ\MoodleCS\moodle\Sniffs\Commenting;
 
 use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
 use MoodleHQ\MoodleCS\moodle\Util\Docblocks;
-use MoodleHQ\MoodleCS\moodle\Util\Tokens;
+use MoodleHQ\MoodleCS\moodle\Util\TokenUtil;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
@@ -78,10 +78,6 @@ class PackageSniff implements Sniff
             $docblock = Docblocks::getDocBlock($phpcsFile, $typePtr);
 
             if ($docblock === null) {
-                $objectName = $this->getObjectName($phpcsFile, $typePtr);
-                $objectType = $this->getObjectType($phpcsFile, $typePtr);
-                $phpcsFile->addError('Missing doc comment for %s %s', $typePtr, 'Missing', [$objectType, $objectName]);
-
                 continue;
             }
 
@@ -103,8 +99,8 @@ class PackageSniff implements Sniff
         array $docblock
     ): bool {
         $tokens = $phpcsFile->getTokens();
-        $objectName = Tokens::getObjectName($phpcsFile, $stackPtr);
-        $objectType = Tokens::getObjectType($phpcsFile, $stackPtr);
+        $objectName = TokenUtil::getObjectName($phpcsFile, $stackPtr);
+        $objectType = TokenUtil::getObjectType($phpcsFile, $stackPtr);
         $expectedPackage = MoodleUtil::getMoodleComponent($phpcsFile, true);
 
         // Nothing to do if we have been unable to determine the package

--- a/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
@@ -1,0 +1,169 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\Commenting;
+
+use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\DummyFile;
+use PHP_CodeSniffer\Ruleset;
+
+/**
+ * Test the MissingDocblockSniff sniff.
+ *
+ * @copyright  2024 onwards Andrew Lyons <andrew@nicols.co.uk>
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\Commenting\MissingDocblockSniff
+ */
+class MissingDocblockSniffTest extends MoodleCSBaseTestCase
+{
+    /**
+     * @dataProvider docblockCorrectnessProvider
+     */
+    public function testMissingDocblockSniff(
+        string $fixture,
+        array $errors,
+        array $warnings
+    ): void {
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Commenting.MissingDocblock');
+        $this->setFixture(sprintf("%s/fixtures/%s.php", __DIR__, $fixture));
+        $this->setWarnings($warnings);
+        $this->setErrors($errors);
+        $this->setComponentMapping([
+            'local_codechecker' => dirname(__DIR__),
+        ]);
+
+        $this->verifyCsResults();
+    }
+
+    public static function docblockCorrectnessProvider(): array {
+        $cases = [
+            'Multiple artifacts in a file' => [
+                'fixture' => 'missing_docblock_multiple_artifacts',
+                'errors' => [
+                    1 => 'Missing docblock for file missing_docblock_multiple_artifacts.php',
+                    34 => 'Missing docblock for function missing_docblock_in_function',
+                    38 => 'Missing docblock for class missing_docblock_in_class',
+                    95 => 'Missing docblock for interface missing_docblock_interface',
+                    118 => 'Missing docblock for trait missing_docblock_trait',
+                    151 => 'Missing docblock for function test_method2',
+                    159 => 'Missing docblock for function test_method',
+                    166 => 'Missing docblock for function test_method',
+                    170 => 'Missing docblock for class example_extends',
+                    175 => 'Missing docblock for class example_implements',
+                ],
+                'warnings' => [
+                    171 => 'Missing docblock for function test_method',
+                    176 => 'Missing docblock for function test_method',
+                ],
+            ],
+            'File level tag, no class' => [
+                'fixture' => 'missing_docblock_class_without_docblock',
+                'errors' => [
+                    11 => 'Missing docblock for class class_without_docblock',
+                ],
+                'warnings' => [],
+            ],
+            'Class only (incorrect whitespace)' => [
+                'fixture' => 'missing_docblock_class_only_with_incorrect_whitespace',
+                'errors' => [
+                    11 => 'Missing docblock for class class_only_with_incorrect_whitespace',
+                ],
+                'warnings' => [],
+            ],
+            'Class only (correct)' => [
+                'fixture' => 'missing_docblock_class_only',
+                'errors' => [],
+                'warnings' => [],
+            ],
+            'Class only with attributes (correct)' => [
+                'fixture' => 'missing_docblock_class_only_with_attributes',
+                'errors' => [],
+                'warnings' => [],
+            ],
+            'Class only with attributes and incorrect whitespace' => [
+                'fixture' => 'missing_docblock_class_only_with_attributes_incorrect_whitespace',
+                'errors' => [
+                    13 => 'Missing docblock for class class_only_with_attributes_incorrect_whitespace',
+                ],
+                'warnings' => [],
+            ],
+            'Class and file (correct)' => [
+                'fixture' => 'missing_docblock_class_and_file',
+                'errors' => [],
+                'warnings' => [],
+            ],
+            'Interface only (correct)' => [
+                'fixture' => 'missing_docblock_interface_only',
+                'errors' => [],
+                'warnings' => [],
+            ],
+            'Trait only (correct)' => [
+                'fixture' => 'missing_docblock_trait_only',
+                'errors' => [],
+                'warnings' => [],
+            ],
+        ];
+
+        if (version_compare(PHP_VERSION, '8.1.0') >= 0) {
+            $cases['Enum only (correct)'] = [
+                'fixture' => 'missing_docblock_enum_only',
+                'errors' => [],
+                'warnings' => [],
+            ];
+        }
+
+        return $cases;
+    }
+
+    public function testMissingDocblockSniffWithTest(): void {
+        $content = <<<EOF
+        phpcs_input_file: /lib/tests/example_test.php
+        <?php
+
+        class example_test extends advanced_testcase {
+            public function setUp(): void {
+            }
+            public function tearDown(): void {
+            }
+            public static function setUpBeforeClass(): void {
+            }
+            public static function tearDownAfterClass(): void {
+            }
+            public function test_the_thing(): void {
+            }
+        }
+        EOF;
+
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Commenting.MissingDocblock');
+        $this->setFixtureFileContent($content);
+        $this->setWarnings([
+            12 => 'Missing docblock for function test_the_thing',
+        ]);
+        $this->setErrors([
+            3 => 'Missing docblock for class example_test',
+        ]);
+        $this->setComponentMapping([
+            'local_codechecker' => dirname(__DIR__),
+        ]);
+
+        $this->verifyCsResults();
+    }
+}

--- a/moodle/Tests/Sniffs/Commenting/PackageSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/PackageSniffTest.php
@@ -39,13 +39,7 @@ class PackageSniffTest extends MoodleCSBaseTestCase
         $this->setComponentMapping([]); // No components available.
 
         $this->setWarnings([]);
-        $this->setErrors([
-            // These are still checked because this doesn't depend on the - missing - component mapping.
-            35 => 'Missing doc comment for class missing_docblock_in_class',
-            38 => 'Missing doc comment for interface missing_docblock_in_interface',
-            41 => 'Missing doc comment for trait missing_docblock_in_trait',
-            44 => 'Missing doc comment for function missing_docblock_in_function',
-        ]);
+        $this->setErrors([]);
 
         $this->verifyCsResults();
     }
@@ -77,8 +71,6 @@ class PackageSniffTest extends MoodleCSBaseTestCase
                 'errors' => [
                     18 => 'DocBlock missing a @package tag for function package_missing. Expected @package local_codechecker',
                     31 => 'DocBlock missing a @package tag for class package_absent. Expected @package local_codechecker',
-                    34 => 'Missing doc comment for function missing_docblock_in_function',
-                    38 => 'Missing doc comment for class missing_docblock_in_class',
                     42 => '@package tag for function package_wrong_in_function. Expected local_codechecker, found wrong_package.',
                     48 => '@package tag for class package_wrong_in_class. Expected local_codechecker, found wrong_package.',
                     57 => 'More than one @package tag found in function package_multiple_in_function',
@@ -87,10 +79,8 @@ class PackageSniffTest extends MoodleCSBaseTestCase
                     78 => 'More than one @package tag found in class package_multiple_in_class_all_wrong',
                     85 => 'More than one @package tag found in interface package_multiple_in_interface_all_wrong',
                     92 => 'More than one @package tag found in trait package_multiple_in_trait_all_wrong',
-                    95 => 'Missing doc comment for interface missing_docblock_interface',
                     101 => 'missing a @package tag for interface missing_package_interface. Expected @package',
                     106 => '@package tag for interface incorrect_package_interface. Expected local_codechecker, found',
-                    118 => 'Missing doc comment for trait missing_docblock_trait',
                     124 => 'DocBlock missing a @package tag for trait missing_package_trait. Expected @package',
                     129 => 'Incorrect @package tag for trait incorrect_package_trait. Expected local_codechecker, found',
                 ],

--- a/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_class_and_file.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_class_and_file.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+/**
+ * File level docblock.
+ */
+
+use example;
+
+/**
+ * Class level docblock.
+ */
+class class_only {
+}

--- a/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_class_only.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_class_only.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+use example;
+
+/**
+ * Class level docblock.
+ */
+class class_only {
+}

--- a/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_class_only_with_attributes.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_class_only_with_attributes.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+use example;
+
+/**
+ * Class level docblock.
+ */
+#[example_attribute]
+#[with_multiple_attributes, and_another_attribute]
+class class_with_docblock_and_attributes {
+}

--- a/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_class_only_with_attributes_incorrect_whitespace.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_class_only_with_attributes_incorrect_whitespace.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+use example;
+
+/**
+ * Class level docblock.
+ */
+#[example_attribute]
+#[with_multiple_attributes, and_another_attribute]
+
+class class_only_with_attributes_incorrect_whitespace {
+}

--- a/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_class_only_with_incorrect_whitespace.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_class_only_with_incorrect_whitespace.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+use example;
+
+/**
+ * Class level docblock but incorrect whitespace.
+ */
+
+class class_only_with_incorrect_whitespace {
+}

--- a/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_class_without_docblock.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_class_without_docblock.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+/**
+ * File level tag
+ */
+
+use example;
+
+class class_without_docblock {
+}

--- a/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_enum_only.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_enum_only.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+use example;
+
+/**
+ * Enum level docblock.
+ */
+enum class_only {
+}

--- a/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_interface_only.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_interface_only.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+use example;
+
+/**
+ * interface level docblock.
+ */
+interface interface_only {
+}

--- a/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_multiple_artifacts.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_multiple_artifacts.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+/**
+ * @package local_codechecker
+ * @return string
+ */
+function package_test(): string {
+    return 'test';
+}
+
+/**
+ * @return string
+ */
+function package_missing(): string {
+    return 'test';
+}
+
+/**
+ * @package local_codechecker
+ */
+class package_present {
+}
+
+/**
+ * Package is absent.
+ */
+class package_absent {
+}
+
+function missing_docblock_in_function(): void {
+    return;
+}
+
+class missing_docblock_in_class {
+}
+
+/**
+ * @package wrong_package
+ */
+function package_wrong_in_function(): void {
+}
+
+/**
+ * @package wrong_package
+ */
+class package_wrong_in_class {
+}
+
+/**
+ * @package local_codechecker
+ * @package some_other
+ */
+function package_multiple_in_function(): void {
+}
+
+/**
+ * @package local_codechecker
+ * @package some_other
+ */
+class package_multiple_in_class {
+}
+
+/**
+ * @package local_codecheckers
+ * @package some_other
+ */
+function package_multiple_in_function_all_wrong(): void {
+}
+
+/**
+ * @package local_codecheckers
+ * @package some_other
+ */
+class package_multiple_in_class_all_wrong {
+}
+
+/**
+ * @package local_codecheckers
+ * @package some_other
+ */
+interface package_multiple_in_interface_all_wrong {
+}
+
+/**
+ * @package local_codecheckers
+ * @package some_other
+ */
+trait package_multiple_in_trait_all_wrong {
+}
+
+interface missing_docblock_interface {
+}
+
+/**
+ * Missing package
+ */
+interface missing_package_interface {
+}
+
+/**
+ * Incorrect package.
+ * @package local_codecheckers
+ */
+interface incorrect_package_interface {
+}
+
+/**
+ * Correct package.
+ * @package local_codechecker
+ */
+interface correct_package_interface {
+}
+
+trait missing_docblock_trait {
+}
+
+/**
+ * Missing package
+ */
+trait missing_package_trait {
+}
+
+/**
+ * Incorrect package.
+ * @package local_codecheckers
+ */
+trait incorrect_package_trait {
+}
+
+/**
+ * Correct package.
+ * @package local_codechecker
+ */
+trait correct_package_trait {
+}
+
+/**
+ * @package local_codechecker
+ */
+class example_class_with_content {
+    /**
+     * Some method.
+     */
+    public static function test_method(): void {
+    }
+
+    public function test_method2(): void {
+    }
+}
+
+/**
+ * @package local_codechecker
+ */
+interface example_interface_with_content {
+    public function test_method(): void;
+}
+
+/**
+ * @package local_codechecker
+ */
+trait example_trait_with_content {
+    public function test_method(): void {
+    }
+}
+
+class example_extends extends example_class_with_content {
+    public function test_method(): void {
+    }
+}
+
+class example_implements implements example_interface_with_content {
+    public function test_method(): void {
+    }
+
+    /**
+     * Found method.
+     */
+    public function test_something_else(): void {
+    }
+}

--- a/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_trait_only.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/missing_docblock_trait_only.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+use example;
+
+/**
+ * Trait level docblock.
+ */
+trait trait_only {
+}

--- a/moodle/Tests/Util/TokenUtilTest.php
+++ b/moodle/Tests/Util/TokenUtilTest.php
@@ -1,0 +1,106 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Util;
+
+use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
+use MoodleHQ\MoodleCS\moodle\Util\TokenUtil;
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Files\DummyFile;
+
+/**
+ * Test the Tokens specific utilities class
+ *
+ * @copyright  2021 onwards Eloy Lafuente (stronk7) {@link https://stronk7.com}
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \MoodleHQ\MoodleCS\moodle\Util\TokenUtil
+ */
+class TokenUtilTest extends MoodleCSBaseTestCase
+{
+    /**
+     * @dataProvider objectPropertiesProvider
+     */
+    public function testGetObjectProperties(
+        string $content,
+        int $type,
+        string $expectedType,
+        string $expectedName
+    ): void {
+        $config = new Config([]);
+        $ruleset = new Ruleset($config);
+
+        $phpcsFile = new DummyFile($content, $ruleset, $config);
+        $phpcsFile->process();
+
+        $stackPtr = $phpcsFile->findNext($type, 0);
+
+        $this->assertEquals($expectedType, TokenUtil::getObjectType($phpcsFile, $stackPtr));
+        $this->assertEquals($expectedName, TokenUtil::getObjectName($phpcsFile, $stackPtr));
+    }
+
+    public static function objectPropertiesProvider(): array {
+        $cases = [
+            'Class name' => [
+                '<?php class Example {}',
+                T_CLASS,
+                'class',
+                'Example',
+            ],
+            'File name' => [
+                // Setting the first line of the file to phpcs_input_file: pathname will set the file name of the dummy file.
+                <<<EOF
+                phpcs_input_file: /path/to/file/example.php
+                <?php class Example {}
+                EOF,
+                T_OPEN_TAG,
+                'file',
+                'example.php',
+            ],
+            'Trait name' => [
+                '<?php trait ExampleTrait {}',
+                T_TRAIT,
+                'trait',
+                'ExampleTrait',
+            ],
+            'Interface name' => [
+                '<?php interface ExampleInterface {}',
+                T_INTERFACE,
+                'interface',
+                'ExampleInterface',
+            ],
+            'Function name' => [
+                '<?php function exampleFunction(): void {}',
+                T_FUNCTION,
+                'function',
+                'exampleFunction',
+            ],
+        ];
+
+        if (version_compare(PHP_VERSION, '8.1.0') >= 0) {
+            $cases['Enum name'] = [
+                '<?php enum ExampleEnum {}',
+                T_ENUM,
+                'enum',
+                'ExampleEnum',
+            ];
+        }
+
+        return $cases;
+    }
+}

--- a/moodle/Util/Docblocks.php
+++ b/moodle/Util/Docblocks.php
@@ -22,6 +22,7 @@ use PHP_CodeSniffer\Exceptions\DeepExitException;
 use PHP_CodeSniffer\Files\DummyFile;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Utilities related to PHP DocBlocks.
@@ -42,6 +43,25 @@ abstract class Docblocks
         File $phpcsFile,
         int $stackPtr
     ): ?array {
+        $docPtr = self::getDocBlockPointer($phpcsFile, $stackPtr);
+        if ($docPtr !== null) {
+            return $phpcsFile->getTokens()[$docPtr];
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the docblock pointer for a file, class, interface, trait, or method.
+     *
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @return null|int
+     */
+    public static function getDocBlockPointer(
+        File $phpcsFile,
+        int $stackPtr
+    ): ?int {
         $tokens = $phpcsFile->getTokens();
         $token = $tokens[$stackPtr];
 
@@ -54,99 +74,113 @@ abstract class Docblocks
             T_DOC_COMMENT_STRING,
         ];
         if ($token['code'] === T_DOC_COMMENT_OPEN_TAG) {
-            return $token;
+            return $stackPtr;
         } elseif ($token['code'] === T_DOC_COMMENT_CLOSE_TAG) {
-            return $tokens[$token['comment_opener']];
+            // The pointer was for a close tag. Fetch the corresponding open tag.
+            return $token['comment_opener'];
         } elseif (in_array($token['code'], $midDocBlockTokens)) {
+            // The pointer was for a token inside the docblock. Fetch the corresponding open tag.
             $commentStart = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr);
-            return $commentStart ? $tokens[$commentStart] : null;
+            return $commentStart ?: null;
         }
 
-        $find   = [
-            T_ABSTRACT   => T_ABSTRACT,
-            T_FINAL      => T_FINAL,
-            T_READONLY   => T_READONLY,
-            T_WHITESPACE => T_WHITESPACE,
-        ];
-
+        // If the pointer was for a file, fetch the doc tag from the open tag.
         if ($tokens[$stackPtr]['code'] === T_OPEN_TAG) {
-            $ignore = [
-                T_WHITESPACE,
-                T_COMMENT,
-            ];
-
-            $stopAtTypes = [
-                T_CLASS,
-                T_INTERFACE,
-                T_TRAIT,
-                T_ENUM,
-                T_FUNCTION,
-                T_CLOSURE,
-                T_PUBLIC,
-                T_PRIVATE,
-                T_PROTECTED,
-                T_FINAL,
-                T_STATIC,
-                T_ABSTRACT,
-                T_READONLY,
-                T_CONST,
-                T_PROPERTY,
-                T_INCLUDE,
-                T_INCLUDE_ONCE,
-                T_REQUIRE,
-                T_REQUIRE_ONCE,
-            ];
-
-            while ($stackPtr = $phpcsFile->findNext($ignore, ($stackPtr + 1), null, true)) {
-                if ($tokens[$stackPtr]['code'] === T_NAMESPACE || $tokens[$stackPtr]['code'] === T_USE) {
-                    $stackPtr = $phpcsFile->findNext(T_SEMICOLON, $stackPtr + 1);
-                    continue;
-                }
-
-                if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
-                    $nextToken = $tokens[$stackPtr]['comment_closer'];
-                    while ($nextToken = $phpcsFile->findNext(T_WHITESPACE, $nextToken + 1, null, true)) {
-                        if ($nextToken && $tokens[$nextToken]['code'] === T_ATTRIBUTE) {
-                            $nextToken = $tokens[$nextToken]['attribute_closer'] + 1;
-                            continue;
-                        }
-                        if (in_array($tokens[$nextToken]['code'], $stopAtTypes)) {
-                            return null;
-                        }
-                        break;
-                    }
-                    return $tokens[$stackPtr];
-                }
-            }
-
-            return null;
+            return self::getDocTagFromOpenTag($phpcsFile, $stackPtr);
         }
+
+        // Assume that the stackPtr is for a class, interface, trait, or method, or some part of them.
+        // Back track over each previous pointer until we find the docblock.
+        // It should be on the line immediately before the pointer.
+        $pointerLine = $tokens[$stackPtr]['line'];
 
         $previousContent = null;
         for ($commentEnd = ($stackPtr - 1); $commentEnd >= 0; $commentEnd--) {
-            if (isset($find[$tokens[$commentEnd]['code']]) === true) {
-                continue;
-            }
-
+            $token = $tokens[$commentEnd];
             if ($previousContent === null) {
                 $previousContent = $commentEnd;
             }
 
-            if (
-                $tokens[$commentEnd]['code'] === T_ATTRIBUTE_END
-                && isset($tokens[$commentEnd]['attribute_opener']) === true
-            ) {
-                $commentEnd = $tokens[$commentEnd]['attribute_opener'];
+            if ($token['code'] === T_ATTRIBUTE_END && isset($token['attribute_opener'])) {
+                $commentEnd = $token['attribute_opener'];
+                $pointerLine = $token['line'];
                 continue;
             }
 
-            break;
+            if ($token['line'] < ($pointerLine - 1)) {
+                // The comment msut be on the line immediately before the pointer, or immediately before the attribute.       z
+                return null;
+            }
+
+            if ($token['code'] === T_DOC_COMMENT_CLOSE_TAG) {
+                // The pointer was for a close tag. Fetch the corresponding open tag.
+                return $token['comment_opener'];
+            }
         }
 
-        if ($commentEnd && $tokens[$commentEnd]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
-            $opener = $tokens[$commentEnd]['comment_opener'];
+        return null; // @codeCoverageIgnore
+    }
 
-            return $tokens[$opener];
+    /**
+     * Get the doc tag from the file open tag.
+     *
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @return null|int
+     */
+    protected static function getDocTagFromOpenTag(
+        File $phpcsFile,
+        int $stackPtr
+    ): ?int {
+        $tokens = $phpcsFile->getTokens();
+
+        $ignore = [
+            T_WHITESPACE,
+            T_COMMENT,
+        ];
+
+        $stopAtTypes = [
+            T_CLASS,
+            T_INTERFACE,
+            T_TRAIT,
+            T_ENUM,
+            T_FUNCTION,
+            T_CLOSURE,
+            T_PUBLIC,
+            T_PRIVATE,
+            T_PROTECTED,
+            T_FINAL,
+            T_STATIC,
+            T_ABSTRACT,
+            T_READONLY,
+            T_CONST,
+            T_PROPERTY,
+            T_INCLUDE,
+            T_INCLUDE_ONCE,
+            T_REQUIRE,
+            T_REQUIRE_ONCE,
+        ];
+
+        while ($stackPtr = $phpcsFile->findNext($ignore, ($stackPtr + 1), null, true)) {
+            if ($tokens[$stackPtr]['code'] === T_NAMESPACE || $tokens[$stackPtr]['code'] === T_USE) {
+                $stackPtr = $phpcsFile->findNext(T_SEMICOLON, $stackPtr + 1);
+                continue;
+            }
+
+            if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+                $nextToken = $tokens[$stackPtr]['comment_closer'];
+                while ($nextToken = $phpcsFile->findNext(T_WHITESPACE, $nextToken + 1, null, true)) {
+                    if ($nextToken && $tokens[$nextToken]['code'] === T_ATTRIBUTE) {
+                        $nextToken = $tokens[$nextToken]['attribute_closer'] + 1;
+                        continue;
+                    }
+                    if (in_array($tokens[$nextToken]['code'], $stopAtTypes)) {
+                        return null;
+                    }
+                    break;
+                }
+                return $stackPtr;
+            }
         }
 
         return null;

--- a/moodle/Util/TokenUtil.php
+++ b/moodle/Util/TokenUtil.php
@@ -1,0 +1,61 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Util;
+
+use PHP_CodeSniffer\Files\File;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+class TokenUtil
+{
+    /**
+     * Get the human-readable object type.
+     *
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @return string
+     */
+    public static function getObjectType(
+        File $phpcsFile,
+        int $stackPtr
+    ): string {
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['code'] === T_OPEN_TAG) {
+            return 'file';
+        }
+        return $tokens[$stackPtr]['content'];
+    }
+
+    /**
+     * Get the human readable object name.
+     *
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @return string
+     */
+    public static function getObjectName(
+        File $phpcsFile,
+        int $stackPtr
+    ): string {
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['code'] === T_OPEN_TAG) {
+            return basename($phpcsFile->getFilename());
+        }
+
+        return ObjectDeclarations::getName($phpcsFile, $stackPtr);
+    }
+}


### PR DESCRIPTION
Replaces:
```php
local_moodlecheck_registry::add_rule('filephpdocpresent')->set_callback('local_moodlecheck_filephpdocpresent');
local_moodlecheck_registry::add_rule('classesdocumented')->set_callback('local_moodlecheck_classesdocumented');
```