### PR TITLE
For PRs, automatically set the author

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,15 @@
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    name: Auto assign PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.0


### PR DESCRIPTION
Each time a PR is opened or reopened, the bot will assign the PR to the author.

(only if an assignee is not set)

You can see how it works @ https://github.com/stronk7/moodle-cs/pull/1 (both open and reopen)

Ciao :-)