### PR TITLE
Type normalisation

### DIFF
--- a/moodle/Tests/Util/TypeUtilTest.php
+++ b/moodle/Tests/Util/TypeUtilTest.php
@@ -66,6 +66,9 @@ final class TypeUtilTest extends MoodleCSBaseTestCase
             ['ARRAY()', 'array'],
             ['INT', 'int'],
             ['Boolean', 'bool'],
+            ['NULL', 'null'],
+            ['FALSE', 'false'],
+            ['true', 'true'],
 
             // Various array syntaxes.
             ['string[]', 'string[]'],

--- a/moodle/Tests/Util/TypeUtilTest.php
+++ b/moodle/Tests/Util/TypeUtilTest.php
@@ -1,0 +1,92 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Util;
+
+use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
+use MoodleHQ\MoodleCS\moodle\Util\TypeUtil;
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Files\DummyFile;
+use PHP_CodeSniffer\Ruleset;
+
+/**
+ * Test the Tokens specific utilities class
+ *
+ *
+ * @copyright Andrew Lyons <andrew@nicols.co.uk>
+ * @license https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \MoodleHQ\MoodleCS\moodle\Util\TypeUtil
+ */
+final class TypeUtilTest extends MoodleCSBaseTestCase
+{
+    /**
+     * @dataProvider getValidTypesProvider
+     */
+    public function testGetValidTypes(string $type, string $expected): void {
+        $config = new Config();
+        $fileContent = <<<EOF
+        <?php
+
+        /** @var {$type} Type description */
+        EOF;
+        $file = new DummyFile($fileContent, new Ruleset($config), $config);
+        $file->process();
+        $ptr = $file->findNext(T_DOC_COMMENT_STRING, 0);
+
+        $this->assertEquals(
+            $expected,
+            TypeUtil::getValidatedType($file, $ptr, $type),
+        );
+    }
+
+    public static function getValidTypesProvider(): array {
+        return [
+            ['string', 'string'],
+            ['int', 'int'],
+            ['integer', 'int'],
+            ['float', 'float'],
+            ['real', 'float'],
+            ['double', 'float'],
+            ['array', 'array'],
+            ['array()', 'array'],
+            ['ARRAY()', 'array'],
+            ['INT', 'int'],
+            ['Boolean', 'bool'],
+
+            // Various array syntaxes.
+            ['string[]', 'string[]'],
+            ['array(int => string)', 'string[]'],
+            ['array(int)', 'int[]'],
+            ['array(int > string)', 'array'],
+
+            // Union types.
+            ['string|int', 'string|int'],
+            ['string|integer', 'string|int'],
+            ['real|integer', 'float|int'],
+
+            // Some example Moodle classes.
+            [\core\formatting::class, \core\formatting::class],
+            [\core\output\notification::class, \core\output\notification::class],
+            [\core_renderer::class, \core_renderer::class],
+
+            // Standard types.
+            ['Traversable', 'Traversable'],
+            [\ArrayAccess::class, \ArrayAccess::class],
+            ['DateTimeImmutable', 'DateTimeImmutable'],
+        ];
+    }
+}

--- a/moodle/Util/TypeUtil.php
+++ b/moodle/Util/TypeUtil.php
@@ -1,0 +1,161 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Util;
+
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Utility class for handling types.
+ *
+ * @copyright Andrew Lyons <andrew@nicols.co.uk>
+ * @license https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class TypeUtil
+{
+    /**
+     * An array of variable types for param/var we will check.
+     *
+     * @var string[]
+     */
+    protected static array $allowedTypes = [
+        'array',
+        'bool',
+        'float',
+        'int',
+        'mixed',
+        'object',
+        'string',
+        'resource',
+        'callable',
+    ];
+
+    /**
+     * Standardise a type to a known type.
+     *
+     * @param string $type The type to standardise.
+     * @return string|null
+     */
+    public static function standardiseType(string $type): ?string {
+        $type = strtolower($type);
+        if (in_array($type, self::$allowedTypes, true)) {
+            return $type;
+        }
+
+        switch ($type) {
+            case 'array()':
+                return 'array';
+            case 'boolean':
+                return 'bool';
+            case 'double':
+            case 'real':
+                return 'float';
+            case 'integer':
+                return 'int';
+            default:
+                return null;
+        }
+    }
+
+
+    /**
+     * Returns a valid variable type for param/var tags.
+     *
+     * If type is not one of the standard types, it must be a custom type.
+     * Returns the correct type name suggestion if type name is invalid.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The position of the current token in the stack passed in $tokens.
+     * @param string $varType The variable type to process.
+     * @return string
+     */
+    public static function suggestType(
+        File $phpcsFile,
+        int $stackPtr,
+        string $varType
+    ): string {
+        $lowerVarType = strtolower($varType);
+        if ($normalisedType = self::standardiseType($lowerVarType)) {
+            return $normalisedType;
+        }
+        if (substr($varType, -2) === '[]') {
+            return sprintf(
+                '%s[]',
+                self::suggestType($phpcsFile, $stackPtr, substr($varType, 0, -2))
+            );
+        }
+
+        if (strpos($lowerVarType, 'array(') !== false) {
+            // Valid array declaration:
+            // array, array(type), array(type1 => type2).
+            $matches = [];
+            $pattern = '/^array\(\s*([^\s^=^>]*)(\s*=>\s*(.*))?\s*\)/i';
+            if (preg_match($pattern, $varType, $matches) !== 0) {
+                $type1 = '';
+                if (isset($matches[1]) === true) {
+                    $type1 = $matches[1];
+                }
+
+                $type2 = '';
+                if (isset($matches[3]) === true) {
+                    $type2 = $matches[3];
+                }
+
+                $type1 = self::suggestType($phpcsFile, $stackPtr, $type1);
+                $type2 = self::suggestType($phpcsFile, $stackPtr, $type2);
+
+                // Note: The phpdoc array syntax only allows you to describe the array value type.
+                // https://docs.phpdoc.org/latest/guide/guides/types.html#arrays
+                if ($type1 && !$type2) {
+                    // This is an array of [type2, type2, type2].
+                    return "{$type1}[]";
+                }
+                // This is an array of [type1 => type2, type1 => type2, type1 => type2].
+                return "{$type2}[]";
+            } else {
+                return 'array';
+            }
+        }
+
+        // Must be a custom type name.
+        return $varType;
+    }
+
+    /**
+     * Validate a type in its entirety.
+     *
+     * The method currently supports built-in types, and Union types.
+     * It does not currently support DNF, or other complex types.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The position of the current token in the stack passed in $tokens.
+     * @param string $type The type to validate.
+     * @return string The validated type.
+     */
+    public static function getValidatedType(
+        File $phpcsFile,
+        int $stackPtr,
+        string $type
+    ): string {
+        $types = explode('|', $type);
+        $validatedTypes = [];
+        foreach ($types as $type) {
+            $validatedTypes[] = self::suggestType($phpcsFile, $stackPtr, $type);
+        }
+        return implode('|', $validatedTypes);
+    }
+}

--- a/moodle/Util/TypeUtil.php
+++ b/moodle/Util/TypeUtil.php
@@ -35,11 +35,14 @@ class TypeUtil
     protected static array $allowedTypes = [
         'array',
         'bool',
+        'false',
         'float',
         'int',
         'mixed',
+        'null',
         'object',
         'string',
+        'true',
         'resource',
         'callable',
     ];


### PR DESCRIPTION
This is part of a followup to #121. It:
* moves the type validation to its own Util class. In retrospect I should have done so whilst writing the Sniff but I was waiting until I wrote the next sniff that used it. However, moving it here allows better unit testing
* adds `null`, `true`, and `false`

It also moves the existing union type checks into the same TypeUtil class.
DNF + Intersection are separate followups.