### PR TITLE
Move unit test method Missing Docblock to new code

### DIFF
--- a/moodle/Sniffs/Commenting/MissingDocblockSniff.php
+++ b/moodle/Sniffs/Commenting/MissingDocblockSniff.php
@@ -181,12 +181,14 @@ class MissingDocblockSniff implements Sniff
             $objectType = TokenUtil::getObjectType($phpcsFile, $typePtr);
 
             if ($isUnitTestFile) {
-                $phpcsFile->addWarning(
-                    'Missing unit test docblock for %s %s',
-                    $typePtr,
-                    'MissingTestDescription',
-                    [$objectType, $objectName]
-                );
+                if (substr($objectName, 0, 5) !== 'test_') {
+                    $phpcsFile->addWarning(
+                        'Missing docblock for %s %s in testcase',
+                        $typePtr,
+                        'MissingTestcaseMethodDescription',
+                        [$objectType, $objectName]
+                    );
+                }
             } elseif ($extendsOrImplements) {
                 $phpcsFile->addWarning('Missing docblock for %s %s', $typePtr, 'Missing', [$objectType, $objectName]);
             } else {

--- a/moodle/Sniffs/Commenting/MissingDocblockSniff.php
+++ b/moodle/Sniffs/Commenting/MissingDocblockSniff.php
@@ -180,7 +180,14 @@ class MissingDocblockSniff implements Sniff
             $objectName = TokenUtil::getObjectName($phpcsFile, $typePtr);
             $objectType = TokenUtil::getObjectType($phpcsFile, $typePtr);
 
-            if ($extendsOrImplements) {
+            if ($isUnitTestFile) {
+                $phpcsFile->addWarning(
+                    'Missing unit test docblock for %s %s',
+                    $typePtr,
+                    'MissingTestDescription',
+                    [$objectType, $objectName]
+                );
+            } elseif ($extendsOrImplements) {
                 $phpcsFile->addWarning('Missing docblock for %s %s', $typePtr, 'Missing', [$objectType, $objectName]);
             } else {
                 $phpcsFile->addError('Missing docblock for %s %s', $typePtr, 'Missing', [$objectType, $objectName]);

--- a/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
@@ -136,7 +136,7 @@ class MissingDocblockSniffTest extends MoodleCSBaseTestCase
                     3 => 'Missing docblock for class example_test',
                 ],
                 'warnings' => [
-                    12 => 'Missing docblock for function test_the_thing',
+                    12 => 'Missing unit test docblock for function test_the_thing',
                 ],
             ],
         ];

--- a/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
@@ -136,7 +136,8 @@ class MissingDocblockSniffTest extends MoodleCSBaseTestCase
                     3 => 'Missing docblock for class example_test',
                 ],
                 'warnings' => [
-                    12 => 'Missing unit test docblock for function test_the_thing',
+                    15 => 'Missing docblock for function this_is_not_a_test in testcase',
+                    18 => 'Missing docblock for function this_is_a_dataprovider in testcase',
                 ],
             ],
         ];

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/testcase_class.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/testcase_class.php
@@ -11,4 +11,10 @@ class example_test extends advanced_testcase {
     }
     public function test_the_thing(): void {
     }
+
+    public function this_is_not_a_test(): void {
+    }
+
+    public static function this_is_a_dataprovider(): array {
+    }
 }


### PR DESCRIPTION
Either:
* Yes, it should
* Yes, but let's use a different Sniff response so it can be filtered and/or ignored in phpcs.xml
* No, it should not

All are very easy to implement.

I've gone for the middle ground for now.