### PR TITLE
Add sniff to detect missing docs for constants

### DIFF
--- a/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
@@ -146,6 +146,15 @@ class MissingDocblockSniffTest extends MoodleCSBaseTestCase
                 'errors' => [],
                 'warnings' => [],
             ],
+            'Constants' => [
+                'fixture' => 'imported_constants',
+                'fixtureFilename' => null,
+                'errors' => [
+                    16 => 'Missing docblock for constant UNDOCUMENTED_CONST',
+                    32 => 'Missing docblock for constant example_class::UNDOCUMENTED_CONST',
+                ],
+                'warnings' => [],
+            ],
             'Testcase' => [
                 'fixture' => 'testcase_class',
                 'fixtureFilename' => '/lib/tests/example_test.php',
@@ -178,6 +187,18 @@ class MissingDocblockSniffTest extends MoodleCSBaseTestCase
                 'fixture' => 'enum_only',
                 'fixtureFilename' => null,
                 'errors' => [],
+                'warnings' => [],
+            ];
+        }
+
+        if (version_compare(PHP_VERSION, '8.3.0') >= 0) {
+            $cases['Typed constants'] = [
+                'fixture' => 'typed_constants',
+                'fixtureFilename' => null,
+                'errors' => [
+                    16 => 'Missing docblock for constant UNDOCUMENTED_CONST',
+                    32 => 'Missing docblock for constant example_class::UNDOCUMENTED_CONST',
+                ],
                 'warnings' => [],
             ];
         }

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/imported_constants.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/imported_constants.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+use these\dont\actually\need\to\point\to\anything;
+use function ns\fun_1;
+use function ns\fun_2 as alias;
+use const ns\CONST_1;
+use const ns\CONST_2 as ALIAS;
+
+use {
+    function ns\fun_3,
+    const ns\const_3
+};
+
+const UNDOCUMENTED_CONST = 1;
+
+/** @var bool A documented bool */
+const DOCUMENTED_BOOL = true;
+
+/**
+ * Another documented constant which does things.
+ *
+ * @var int
+ */
+const DOCUMENTED_INT = 1;
+
+/**
+ * Example class.
+ */
+class example_class {
+    const UNDOCUMENTED_CONST = 1;
+
+    /** @var bool A documented bool */
+    const DOCUMENTED_BOOL = true;
+
+    /**
+     * Another documented constant which does things.
+     *
+     * @var int
+     */
+    const DOCUMENTED_INT = 1;
+
+}

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/typed_constants.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/typed_constants.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+use these\dont\actually\need\to\point\to\anything;
+use function ns\fun_1;
+use function ns\fun_2 as alias;
+use const ns\CONST_1;
+use const ns\CONST_2 as ALIAS;
+
+use {
+    function ns\fun_3,
+    const ns\const_3
+};
+
+const UNDOCUMENTED_CONST = 1;
+
+/** @var bool A documented bool */
+const DOCUMENTED_BOOL = true;
+
+/**
+ * Another documented constant which does things.
+ *
+ * @var int
+ */
+const DOCUMENTED_INT = 1;
+
+/**
+ * Example class.
+ */
+class example_class {
+    const int UNDOCUMENTED_CONST = 1;
+
+    /** @var bool A documented bool */
+    const bool DOCUMENTED_BOOL = true;
+
+    /**
+     * Another documented constant which does things.
+     *
+     * @var int
+     */
+    const int DOCUMENTED_INT = 1;
+
+}


### PR DESCRIPTION
Replaces constsdocumented check.

https://github.com/moodlehq/moodle-local_moodlecheck/pull/140