### PR TITLE
Add test for multiline attributes for MissingDocblockSniff

### DIFF
--- a/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
@@ -129,6 +129,12 @@ class MissingDocblockSniffTest extends MoodleCSBaseTestCase
                 'errors' => [],
                 'warnings' => [],
             ],
+            'Docblock with attributes on function (correct)' => [
+                'fixture' => 'docblock_with_multiline_attributes',
+                'fixtureFilename' => null,
+                'errors' => [],
+                'warnings' => [],
+            ],
             'Testcase' => [
                 'fixture' => 'testcase_class',
                 'fixtureFilename' => '/lib/tests/example_test.php',

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/docblock_with_multiline_attributes.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/docblock_with_multiline_attributes.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file contains multiple testcases for multi line attributes.
+ */
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+/**
+ * Example class. 
+ */
+#[\Attribute(
+    attr1: 'asdf',
+    attr2: 'asdf',
+)]
+class class_multiline_attribute {
+
+    /**
+     * Method attribute.
+     */
+    #[\Attribute(
+        attr1: 'asdf',
+        attr2: 'asdf',
+    )]
+    function method_multiline_attribute(): void {
+    }
+}
+
+/**
+ * Interface with multiline attributes.
+ */
+#[\Attribute(
+    attr1: 'asdf',
+    attr2: 'asdf',
+)]
+interface interface_multiline_attribute {
+}
+
+/**
+ * Trait with multiline attributes.
+ */
+
+#[\Attribute(
+    attr1: 'asdf',
+    attr2: 'asdf',
+)]
+trait trait_multiline_attribute {
+}


### PR DESCRIPTION
This are two test cases for #130.