### PR TITLE
Fix docblocks before Multiline attributes

### DIFF
--- a/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
@@ -108,6 +108,23 @@ class MissingDocblockSniffTest extends MoodleCSBaseTestCase
                 'fixtureFilename' => null,
                 'errors' => [
                     13 => 'Missing docblock for class class_only_with_attributes_incorrect_whitespace',
+                    20 => 'Missing docblock for function method_only_with_attributes_incorrect_whitespace',
+                ],
+                'warnings' => [],
+            ],
+            'Interface only with attributes and incorrect whitespace' => [
+                'fixture' => 'interface_only_with_attributes_incorrect_whitespace',
+                'fixtureFilename' => null,
+                'errors' => [
+                    13 => 'Missing docblock for interface interface_only_with_attributes_incorrect_whitespace',
+                ],
+                'warnings' => [],
+            ],
+            'Trait only with attributes and incorrect whitespace' => [
+                'fixture' => 'trait_only_with_attributes_incorrect_whitespace',
+                'fixtureFilename' => null,
+                'errors' => [
+                    13 => 'Missing docblock for trait trait_only_with_attributes_incorrect_whitespace',
                 ],
                 'warnings' => [],
             ],

--- a/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
@@ -129,12 +129,6 @@ class MissingDocblockSniffTest extends MoodleCSBaseTestCase
                 'errors' => [],
                 'warnings' => [],
             ],
-            'Docblock with attributes on function (correct)' => [
-                'fixture' => 'docblock_with_multiline_attributes',
-                'fixtureFilename' => null,
-                'errors' => [],
-                'warnings' => [],
-            ],
             'Testcase' => [
                 'fixture' => 'testcase_class',
                 'fixtureFilename' => '/lib/tests/example_test.php',
@@ -147,6 +141,16 @@ class MissingDocblockSniffTest extends MoodleCSBaseTestCase
                 ],
             ],
         ];
+
+        if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
+            $cases['Multiline attributes'] = [
+                'fixture' => 'docblock_with_multiline_attributes',
+                'fixtureFilename' => null,
+                'errors' => [
+                ],
+                'warnings' => [],
+            ];
+        }
 
         if (version_compare(PHP_VERSION, '8.1.0') >= 0) {
             $cases['Enum only (correct)'] = [

--- a/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
@@ -129,6 +129,12 @@ class MissingDocblockSniffTest extends MoodleCSBaseTestCase
                 'errors' => [],
                 'warnings' => [],
             ],
+            'Docblock with attributes on function (correct)' => [
+                'fixture' => 'docblock_with_multiline_attributes',
+                'fixtureFilename' => null,
+                'errors' => [],
+                'warnings' => [],
+            ],
             'Testcase' => [
                 'fixture' => 'testcase_class',
                 'fixtureFilename' => '/lib/tests/example_test.php',

--- a/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
@@ -147,6 +147,10 @@ class MissingDocblockSniffTest extends MoodleCSBaseTestCase
                 'fixture' => 'docblock_with_multiline_attributes',
                 'fixtureFilename' => null,
                 'errors' => [
+                    59 => 'Missing docblock for class class_multiline_attribute_space_between',
+                    69 => 'Missing docblock for function method_multiline_attribute_space_between',
+                    81 => 'Missing docblock for interface interface_multiline_attribute_space_between',
+                    92 => 'Missing docblock for trait trait_multiline_attribute_space_between',
                 ],
                 'warnings' => [],
             ];

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/class_only_with_attributes_incorrect_whitespace.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/class_only_with_attributes_incorrect_whitespace.php
@@ -11,4 +11,12 @@ use example;
 #[with_multiple_attributes, and_another_attribute]
 
 class class_only_with_attributes_incorrect_whitespace {
+    /**
+     * Method level docblock.
+     */
+    #[example_attribute]
+    #[with_multiple_attributes, and_another_attribute]
+
+    function method_only_with_attributes_incorrect_whitespace(): void {
+    }
 }

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/docblock_with_multiline_attributes.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/docblock_with_multiline_attributes.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file contains multiple testcases for multi line attributes.
+ */
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+/**
+ * Example class. 
+ */
+#[\Attribute(
+    attr1: 'asdf',
+    attr2: 'asdf',
+)]
+class class_multiline_attribute {
+
+    /**
+     * Method attribute.
+     */
+    #[\Attribute(
+        attr1: 'asdf',
+        attr2: 'asdf',
+    )]
+    function method_multiline_attribute(): void {
+    }
+}
+
+/**
+ * Interface with multiline attributes.
+ */
+#[\Attribute(
+    attr1: 'asdf',
+    attr2: 'asdf',
+)]
+interface interface_multiline_attribute {
+}
+
+/**
+ * Trait with multiline attributes.
+ */
+
+#[\Attribute(
+    attr1: 'asdf',
+    attr2: 'asdf',
+)]
+trait trait_multiline_attribute {
+}

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/docblock_with_multiline_attributes.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/docblock_with_multiline_attributes.php
@@ -41,10 +41,53 @@ interface interface_multiline_attribute {
 /**
  * Trait with multiline attributes.
  */
-
 #[\Attribute(
     attr1: 'asdf',
     attr2: 'asdf',
 )]
 trait trait_multiline_attribute {
+}
+
+/**
+ * Example class. 
+ */
+
+#[\Attribute(
+    attr1: 'asdf',
+    attr2: 'asdf',
+)]
+class class_multiline_attribute_space_between {
+
+    /**
+     * Method attribute.
+     */
+
+    #[\Attribute(
+        attr1: 'asdf',
+        attr2: 'asdf',
+    )]
+    function method_multiline_attribute_space_between(): void {
+    }
+}
+
+/**
+ * Interface with multiline attributes.
+ */
+
+#[\Attribute(
+    attr1: 'asdf',
+    attr2: 'asdf',
+)]
+interface interface_multiline_attribute_space_between {
+}
+
+/**
+ * Trait with multiline attributes and space between.
+ */
+
+ #[\Attribute(
+    attr1: 'asdf',
+    attr2: 'asdf',
+)]
+trait trait_multiline_attribute_space_between {
 }

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/docblock_with_multiline_attributes.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/docblock_with_multiline_attributes.php
@@ -9,9 +9,9 @@ namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
 defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
 
 /**
- * Example class. 
+ * Example class.
  */
-#[\Attribute(
+#[someattribute(
     attr1: 'asdf',
     attr2: 'asdf',
 )]
@@ -20,7 +20,7 @@ class class_multiline_attribute {
     /**
      * Method attribute.
      */
-    #[\Attribute(
+    #[someattribute(
         attr1: 'asdf',
         attr2: 'asdf',
     )]
@@ -31,7 +31,7 @@ class class_multiline_attribute {
 /**
  * Interface with multiline attributes.
  */
-#[\Attribute(
+#[someattribute(
     attr1: 'asdf',
     attr2: 'asdf',
 )]
@@ -41,7 +41,7 @@ interface interface_multiline_attribute {
 /**
  * Trait with multiline attributes.
  */
-#[\Attribute(
+#[someattribute(
     attr1: 'asdf',
     attr2: 'asdf',
 )]
@@ -52,7 +52,7 @@ trait trait_multiline_attribute {
  * Example class. 
  */
 
-#[\Attribute(
+#[someattribute(
     attr1: 'asdf',
     attr2: 'asdf',
 )]
@@ -62,7 +62,7 @@ class class_multiline_attribute_space_between {
      * Method attribute.
      */
 
-    #[\Attribute(
+    #[someattribute(
         attr1: 'asdf',
         attr2: 'asdf',
     )]
@@ -74,7 +74,7 @@ class class_multiline_attribute_space_between {
  * Interface with multiline attributes.
  */
 
-#[\Attribute(
+#[someattribute(
     attr1: 'asdf',
     attr2: 'asdf',
 )]
@@ -85,7 +85,7 @@ interface interface_multiline_attribute_space_between {
  * Trait with multiline attributes and space between.
  */
 
- #[\Attribute(
+ #[someattribute(
     attr1: 'asdf',
     attr2: 'asdf',
 )]

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/interface_only_with_attributes_incorrect_whitespace.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/interface_only_with_attributes_incorrect_whitespace.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+use example;
+
+/**
+ * Interface level docblock.
+ */
+#[example_attribute]
+#[with_multiple_attributes, and_another_attribute]
+
+interface interface_only_with_attributes_incorrect_whitespace {
+}

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/trait_only_with_attributes_incorrect_whitespace.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/trait_only_with_attributes_incorrect_whitespace.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+use example;
+
+/**
+ * Trait level docblock.
+ */
+#[example_attribute]
+#[with_multiple_attributes, and_another_attribute]
+
+trait trait_only_with_attributes_incorrect_whitespace {
+}

--- a/moodle/Util/Docblocks.php
+++ b/moodle/Util/Docblocks.php
@@ -215,12 +215,12 @@ abstract class Docblocks
 
             if ($token['code'] === T_ATTRIBUTE_END && isset($token['attribute_opener'])) {
                 $commentEnd = $token['attribute_opener'];
-                $pointerLine = $token['line'];
+                $pointerLine = $tokens[$commentEnd]['line'];
                 continue;
             }
 
             if ($token['line'] < ($pointerLine - 1)) {
-                // The comment msut be on the line immediately before the pointer, or immediately before the attribute.       z
+                // The comment must be on the line immediately before the pointer, or immediately before the attribute.       z
                 return null;
             }
 


### PR DESCRIPTION
The line no was not updated to the line of the opening attribute.

Thanks to @ziegenberg for the test here.
Note: I had to amend it because PHP 7.4 cannot support multiline attributes, only single line (which are treated as comments)

Also please note that it is not necessary to sign-off your own commits. Typically the `Signed-off by` is used for peer code review.