### PR TITLE
Deprecated items do not need a description

### DIFF
--- a/moodle/Sniffs/Commenting/CategorySniff.php
+++ b/moodle/Sniffs/Commenting/CategorySniff.php
@@ -46,15 +46,21 @@ class CategorySniff implements Sniff
      * @param int $stackPtr The position in the stack.
      */
     public function process(File $phpcsFile, $stackPtr) {
-        $categoryTokens = Docblocks::getMatchingDocTags($phpcsFile, $stackPtr, '@category');
+        $docPtr = Docblocks::getDocBlockPointer($phpcsFile, $stackPtr);
+        if (empty($docPtr)) {
+            // It should not be possible to reach this line. It is a safety check.
+            return; // @codeCoverageIgnore
+        }
+
+        $categoryTokens = Docblocks::getMatchingDocTags($phpcsFile, $docPtr, '@category');
         if (empty($categoryTokens)) {
             return;
         }
 
         $tokens = $phpcsFile->getTokens();
+        $docblock = $tokens[$docPtr];
         $apis = MoodleUtil::getMoodleApis($phpcsFile);
 
-        $docblock = Docblocks::getDocBlock($phpcsFile, $stackPtr);
         foreach ($categoryTokens as $tokenPtr) {
             $categoryValuePtr = $phpcsFile->findNext(
                 T_DOC_COMMENT_STRING,

--- a/moodle/Sniffs/Commenting/DocblockDescriptionSniff.php
+++ b/moodle/Sniffs/Commenting/DocblockDescriptionSniff.php
@@ -79,6 +79,12 @@ class DocblockDescriptionSniff implements Sniff
             }
             $faultAtLine = $tokens[$stopAt]['line'];
 
+            $deprecatedTagPtrs = Docblocks::getMatchingDocTags($phpcsFile, $docblockPtr, '@deprecated');
+            if (count($deprecatedTagPtrs) > 0) {
+                // Skip if the docblock contains a @deprecated tag.
+                continue;
+            }
+
             // Skip to the next T_DOC_COMMENT_STAR line. We do not accept single line docblocks.
             $docblockLinePtr = $docblockPtr;
             while ($docblockLinePtr = $phpcsFile->findNext(T_DOC_COMMENT_STAR, $docblockLinePtr + 1, $stopAt)) {

--- a/moodle/Sniffs/Commenting/FileExpectedTagsSniff.php
+++ b/moodle/Sniffs/Commenting/FileExpectedTagsSniff.php
@@ -93,9 +93,9 @@ class FileExpectedTagsSniff implements Sniff
      * @param int $stackPtr The position in the stack.
      */
     private function processFileCopyright(File $phpcsFile, $stackPtr): void {
-        $copyrightTokens = Docblocks::getMatchingDocTags($phpcsFile, $stackPtr, '@copyright');
+        $docPtr = Docblocks::getDocBlockPointer($phpcsFile, $stackPtr);
+        $copyrightTokens = Docblocks::getMatchingDocTags($phpcsFile, $docPtr, '@copyright');
         if (empty($copyrightTokens)) {
-            $docPtr = Docblocks::getDocBlockPointer($phpcsFile, $stackPtr);
             if (empty($docPtr)) {
                 $docPtr = $stackPtr;
             }
@@ -117,9 +117,9 @@ class FileExpectedTagsSniff implements Sniff
      */
     private function processFileLicense(File $phpcsFile, $stackPtr): void {
         $tokens = $phpcsFile->getTokens();
-        $foundTokens = Docblocks::getMatchingDocTags($phpcsFile, $stackPtr, '@license');
+        $docPtr = Docblocks::getDocBlockPointer($phpcsFile, $stackPtr);
+        $foundTokens = Docblocks::getMatchingDocTags($phpcsFile, $docPtr, '@license');
         if (empty($foundTokens)) {
-            $docPtr = Docblocks::getDocBlockPointer($phpcsFile, $stackPtr);
             if ($docPtr) {
                 $phpcsFile->addError(
                     'Missing @license tag',

--- a/moodle/Sniffs/Commenting/MissingDocblockSniff.php
+++ b/moodle/Sniffs/Commenting/MissingDocblockSniff.php
@@ -89,14 +89,14 @@ class MissingDocblockSniff implements Sniff
                 continue;
             }
 
-            if (!Docblocks::getDocBlock($phpcsFile, $typePtr)) {
+            if (!Docblocks::getDocBlockPointer($phpcsFile, $typePtr)) {
                 $missingDocblocks[] = $typePtr;
             }
         }
 
         if ($artifactCount !== 1) {
             // See if there is a file docblock.
-            $fileblock = Docblocks::getDocBlock($phpcsFile, $stackPtr);
+            $fileblock = Docblocks::getDocBlockPointer($phpcsFile, $stackPtr);
 
             if ($fileblock === null) {
                 $objectName = TokenUtil::getObjectName($phpcsFile, $stackPtr);
@@ -176,7 +176,7 @@ class MissingDocblockSniff implements Sniff
                 }
             }
 
-            if (!Docblocks::getDocBlock($phpcsFile, $typePtr)) {
+            if (!Docblocks::getDocBlockPointer($phpcsFile, $typePtr)) {
                 $missingDocblocks[$typePtr] = $extendsOrImplements;
             }
         }
@@ -229,7 +229,7 @@ class MissingDocblockSniff implements Sniff
                 }
             }
 
-            if (Docblocks::getDocBlock($phpcsFile, $typePtr)) {
+            if (Docblocks::getDocBlockPointer($phpcsFile, $typePtr)) {
                 // This is documented.
                 continue;
             }

--- a/moodle/Sniffs/Commenting/ValidTagsSniff.php
+++ b/moodle/Sniffs/Commenting/ValidTagsSniff.php
@@ -49,7 +49,7 @@ class ValidTagsSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         while ($docPtr = $phpcsFile->findNext(T_DOC_COMMENT_OPEN_TAG, $stackPtr)) {
-            $docblock = Docblocks::getDocBlock($phpcsFile, $docPtr);
+            $docblock = $tokens[$docPtr];
             foreach ($docblock['comment_tags'] as $tagPtr) {
                 $tagName = ltrim($tokens[$tagPtr]['content'], '@');
                 if (!Docblocks::isValidTag($phpcsFile, $tagPtr)) {

--- a/moodle/Tests/Sniffs/Commenting/fixtures/DocblockDescription/standard.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/DocblockDescription/standard.php
@@ -58,3 +58,8 @@ trait trait_with_docblock_but_no_description {}
  * @license
  */
 function function_with_docblock_but_no_description() {}
+
+/**
+ * @deprecated
+ */
+function function_with_deprecated_tag() {}

--- a/moodle/Tests/Util/DocblocksTest.php
+++ b/moodle/Tests/Util/DocblocksTest.php
@@ -33,7 +33,7 @@ use PHP_CodeSniffer\Ruleset;
  */
 class DocblocksTest extends MoodleCSBaseTestCase
 {
-    public function testGetDocBlock(): void {
+    public function testgetDocBlockPointer(): void {
         $phpcsConfig = new Config();
         $phpcsRuleset = new Ruleset($phpcsConfig);
         $phpcsFile = new \PHP_CodeSniffer\Files\LocalFile(
@@ -45,7 +45,7 @@ class DocblocksTest extends MoodleCSBaseTestCase
         $phpcsFile->process();
         $filePointer = $phpcsFile->findNext(T_OPEN_TAG, 0);
 
-        $docBlock = Docblocks::getDocBlock($phpcsFile, $filePointer);
+        $docBlock = Docblocks::getDocBlockPointer($phpcsFile, $filePointer);
         $this->assertNull($docBlock);
     }
 
@@ -62,20 +62,21 @@ class DocblocksTest extends MoodleCSBaseTestCase
         $filePointer = $phpcsFile->findNext(T_OPEN_TAG, 0);
         $classPointer = $phpcsFile->findNext(T_CLASS, 0);
 
-        $fileDocBlock = Docblocks::getDocBlock($phpcsFile, $filePointer);
-        $this->assertNotNull($fileDocBlock);
-        $this->assertCount(1, Docblocks::getMatchingDocTags($phpcsFile, $filePointer, '@copyright'));
-        $this->assertCount(0, Docblocks::getMatchingDocTags($phpcsFile, $filePointer, '@property'));
+        $this->assertCount(0, Docblocks::getMatchingDocTags($phpcsFile, null, '@copyright'));
 
-        $classDocBlock = Docblocks::getDocBlock($phpcsFile, $classPointer);
-        $this->assertNotNull($classDocBlock);
-        $this->assertNotEquals($fileDocBlock, $classDocBlock);
-        $this->assertCount(1, Docblocks::getMatchingDocTags($phpcsFile, $classPointer, '@copyright'));
-        $this->assertCount(2, Docblocks::getMatchingDocTags($phpcsFile, $classPointer, '@property'));
+        $fileDocBlockPtr = Docblocks::getDocBlockPointer($phpcsFile, $filePointer);
+        $this->assertNotNull($fileDocBlockPtr);
+        $this->assertCount(1, Docblocks::getMatchingDocTags($phpcsFile, $fileDocBlockPtr, '@copyright'));
+        $this->assertCount(0, Docblocks::getMatchingDocTags($phpcsFile, $fileDocBlockPtr, '@property'));
+
+        $classDocBlockPtr = Docblocks::getDocBlockPointer($phpcsFile, $classPointer);
+        $this->assertNotNull($classDocBlockPtr);
+        $this->assertNotEquals($fileDocBlockPtr, $classDocBlockPtr);
+        $this->assertCount(1, Docblocks::getMatchingDocTags($phpcsFile, $classDocBlockPtr, '@copyright'));
+        $this->assertCount(2, Docblocks::getMatchingDocTags($phpcsFile, $classDocBlockPtr, '@property'));
 
         $methodPointer = $phpcsFile->findNext(T_FUNCTION, $classPointer);
-        $this->assertNull(Docblocks::getDocBlock($phpcsFile, $methodPointer));
-        $this->assertCount(0, Docblocks::getMatchingDocTags($phpcsFile, $methodPointer, '@property'));
+        $this->assertNull(Docblocks::getDocBlockPointer($phpcsFile, $methodPointer));
 
         // Get the docblock from pointers at the start, middle, and end, of a docblock.
         $tokens = $phpcsFile->getTokens();
@@ -83,17 +84,17 @@ class DocblocksTest extends MoodleCSBaseTestCase
         $endDocPointer = $phpcsFile->findNext(T_DOC_COMMENT_CLOSE_TAG, $startDocPointer);
         $middleDocPointer = $phpcsFile->findNext(T_DOC_COMMENT_STRING, $startDocPointer, $endDocPointer);
 
-        $docblock = Docblocks::getDocBlock($phpcsFile, $startDocPointer);
-        $this->assertIsArray($docblock);
-        $this->assertEquals($tokens[$startDocPointer], $docblock);
+        $docblock = Docblocks::getDocBlockPointer($phpcsFile, $startDocPointer);
+        $this->assertIsInt($docblock);
+        $this->assertEquals($startDocPointer, $docblock);
 
-        $docblock = Docblocks::getDocBlock($phpcsFile, $middleDocPointer);
-        $this->assertIsArray($docblock);
-        $this->assertEquals($tokens[$startDocPointer], $docblock);
+        $docblock = Docblocks::getDocBlockPointer($phpcsFile, $middleDocPointer);
+        $this->assertIsInt($docblock);
+        $this->assertEquals($startDocPointer, $docblock);
 
-        $docblock = Docblocks::getDocBlock($phpcsFile, $endDocPointer);
-        $this->assertIsArray($docblock);
-        $this->assertEquals($tokens[$startDocPointer], $docblock);
+        $docblock = Docblocks::getDocBlockPointer($phpcsFile, $endDocPointer);
+        $this->assertIsInt($docblock);
+        $this->assertEquals($startDocPointer, $docblock);
     }
 
     public function testGetDocBlockClassOnly(): void {
@@ -109,18 +110,17 @@ class DocblocksTest extends MoodleCSBaseTestCase
         $filePointer = $phpcsFile->findNext(T_OPEN_TAG, 0);
         $classPointer = $phpcsFile->findNext(T_CLASS, 0);
 
-        $fileDocBlock = Docblocks::getDocBlock($phpcsFile, $filePointer);
+        $fileDocBlock = Docblocks::getDocBlockPointer($phpcsFile, $filePointer);
         $this->assertNull($fileDocBlock);
 
-        $classDocBlock = Docblocks::getDocBlock($phpcsFile, $classPointer);
-        $this->assertNotNull($classDocBlock);
-        $this->assertNotEquals($fileDocBlock, $classDocBlock);
-        $this->assertCount(1, Docblocks::getMatchingDocTags($phpcsFile, $classPointer, '@copyright'));
-        $this->assertCount(2, Docblocks::getMatchingDocTags($phpcsFile, $classPointer, '@property'));
+        $classDocBlockPtr = Docblocks::getDocBlockPointer($phpcsFile, $classPointer);
+        $this->assertNotNull($classDocBlockPtr);
+        $this->assertNotEquals($fileDocBlock, $classDocBlockPtr);
+        $this->assertCount(1, Docblocks::getMatchingDocTags($phpcsFile, $classDocBlockPtr, '@copyright'));
+        $this->assertCount(2, Docblocks::getMatchingDocTags($phpcsFile, $classDocBlockPtr, '@property'));
 
         $methodPointer = $phpcsFile->findNext(T_FUNCTION, $classPointer);
-        $this->assertNull(Docblocks::getDocBlock($phpcsFile, $methodPointer));
-        $this->assertCount(0, Docblocks::getMatchingDocTags($phpcsFile, $methodPointer, '@property'));
+        $this->assertNull(Docblocks::getDocBlockPointer($phpcsFile, $methodPointer));
     }
 
     /**
@@ -140,10 +140,10 @@ class DocblocksTest extends MoodleCSBaseTestCase
         $filePointer = $phpcsFile->findNext(T_OPEN_TAG, 0);
         $classPointer = $phpcsFile->findNext(T_CLASS, 0);
 
-        $fileDocBlock = Docblocks::getDocBlock($phpcsFile, $filePointer);
+        $fileDocBlock = Docblocks::getDocBlockPointer($phpcsFile, $filePointer);
         $this->assertNotNull($fileDocBlock);
 
-        $classDocBlock = Docblocks::getDocBlock($phpcsFile, $classPointer);
+        $classDocBlock = Docblocks::getDocBlockPointer($phpcsFile, $classPointer);
         $this->assertNull($classDocBlock);
     }
 
@@ -164,10 +164,10 @@ class DocblocksTest extends MoodleCSBaseTestCase
         $filePointer = $phpcsFile->findNext(T_OPEN_TAG, 0);
         $classPointer = $phpcsFile->findNext(T_CLASS, 0);
 
-        $fileDocBlock = Docblocks::getDocBlock($phpcsFile, $filePointer);
+        $fileDocBlock = Docblocks::getDocBlockPointer($phpcsFile, $filePointer);
         $this->assertNotNull($fileDocBlock);
 
-        $classDocBlock = Docblocks::getDocBlock($phpcsFile, $classPointer);
+        $classDocBlock = Docblocks::getDocBlockPointer($phpcsFile, $classPointer);
         $this->assertNull($classDocBlock);
     }
 

--- a/moodle/Util/Docblocks.php
+++ b/moodle/Util/Docblocks.php
@@ -145,25 +145,6 @@ abstract class Docblocks
     ];
 
     /**
-     * Get the docblock for a file, class, interface, trait, or method.
-     *
-     * @param File $phpcsFile
-     * @param int $stackPtr
-     * @return null|array
-     */
-    public static function getDocBlock(
-        File $phpcsFile,
-        int $stackPtr
-    ): ?array {
-        $docPtr = self::getDocBlockPointer($phpcsFile, $stackPtr);
-        if ($docPtr !== null) {
-            return $phpcsFile->getTokens()[$docPtr];
-        }
-
-        return null;
-    }
-
-    /**
      * Get the docblock pointer for a file, class, interface, trait, or method.
      *
      * @param File $phpcsFile
@@ -301,17 +282,23 @@ abstract class Docblocks
         return null;
     }
 
+    /**
+     * Get the tags that match the given tag name.
+     *
+     * @param File $phpcsFile
+     * @param int|null $stackPtr The pointer of the docblock
+     * @param string $tagName
+     */
     public static function getMatchingDocTags(
         File $phpcsFile,
-        int $stackPtr,
+        ?int $stackPtr,
         string $tagName
     ): array {
-        $tokens = $phpcsFile->getTokens();
-        $docblock = self::getDocBlock($phpcsFile, $stackPtr);
-        if ($docblock === null) {
+        if ($stackPtr === null) {
             return [];
         }
-
+        $tokens = $phpcsFile->getTokens();
+        $docblock = $tokens[$stackPtr];
         $matchingTags = [];
         foreach ($docblock['comment_tags'] as $tag) {
             if ($tokens[$tag]['content'] === $tagName) {


### PR DESCRIPTION
Raised by @ziegenberg 

Note: I've included an extra commit her eto slightly refactor the Docblocks util to use the docblockPtr rather than find it from an unrelated pointer. This is much more efficient and I should have done this originally.