### PR TITLE
Properties should not be tested for regular constructors (Fixes #142)

### DIFF
--- a/moodle/Tests/Sniffs/Commenting/VariableCommentSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/VariableCommentSniffTest.php
@@ -90,6 +90,14 @@ class VariableCommentSniffTest extends MoodleCSBaseTestCase
                 ],
                 'warnings' => [],
             ],
+            'Constructor with mixed CPP' => [
+                'fixture' => 'constructor_with_mixed_property_promotion',
+                'errors' => [
+                    21 => 'Missing member variable doc comment',
+                ],
+                'warnings' => [
+                ],
+            ],
         ];
 
         if (version_compare(PHP_VERSION, '8.0.0') >= 0) {

--- a/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/constructor_with_mixed_property_promotion.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/constructor_with_mixed_property_promotion.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+class constructor_with_mixed_property_promotion {
+    /**
+     * Constructor
+     *
+     * @param string $serverurl a Moodle URL
+     * @param string $token the token used to do the web service call
+     * @param string $example
+     * @param string $example2
+     * @param string $example3
+     */
+    public function __construct(
+        $serverurl,
+        string $token,
+        /** @var string The example */
+        protected string $example,
+        string $example2,
+        protected string $example3
+    ) {
+    }
+}


### PR DESCRIPTION
Only properties which define a visibility and therefore are promoted constructor properties are required to define a variable docblock.