### PR TITLE
Update BoilerplateCommentSniff and add fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ## [Unreleased]
 ### Added
 - The existing `moodle.PHPUnit.TestCaseCovers` sniff now detects multiple uses of the `@coversDefaultClass` annotation. Only one is allowed by class.
+- The existing `moodle.Files.BoilerplateComment` sniff now performs more checks (spacing, placement, blank lines, ...) and is able to fix many of them.
 
 ### Changed
 - Made codes for `moodle.Commenting.MissingDocblock` more specific to the scenario (Fixes #154).

--- a/moodle/Tests/FilesBoilerPlateCommentTest.php
+++ b/moodle/Tests/FilesBoilerPlateCommentTest.php
@@ -174,12 +174,28 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase
     }
 
     /**
-     * Assert that boilerplate is followed by a single newline.
+     * Assert that boilerplate is followed by a single newline (detect and remove excessive)
      */
     public function testMoodleFilesBoilerplateCommentTrailingWhitespace() {
         $this->setStandard('moodle');
         $this->setSniff('moodle.Files.BoilerplateComment');
         $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/trailing_whitespace.php');
+
+        $this->setErrors([
+            16 => 'SingleTrailingNewLine',
+        ]);
+        $this->setWarnings([]);
+
+        $this->verifyCsResults();
+    }
+
+    /**
+     * Assert that boilerplate is followed by a single newline (detect and fix missing)
+     */
+    public function testMoodleFilesBoilerplateCommentTrailingWhitespaceMissing() {
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/trailing_whitespace_missing.php');
 
         $this->setErrors([
             16 => 'SingleTrailingNewLine',

--- a/moodle/Tests/FilesBoilerPlateCommentTest.php
+++ b/moodle/Tests/FilesBoilerPlateCommentTest.php
@@ -69,7 +69,7 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase
         $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/blank.php');
 
         $this->setErrors([
-            2 => 'followed by exactly one newline',
+            2 => 'not found at first line',
         ]);
         $this->setWarnings([]);
 
@@ -82,7 +82,7 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase
         $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/short.php');
 
         $this->setErrors([
-            14 => 'FileTooShort',
+            14 => 'CommentEndedTooSoon',
         ]);
         $this->setWarnings([]);
 
@@ -95,7 +95,20 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase
         $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/short_empty.php');
 
         $this->setErrors([
-            1 => 'FileTooShort',
+            1 => 'NoBoilerplateComment',
+        ]);
+        $this->setWarnings([]);
+
+        $this->verifyCsResults();
+    }
+
+    public function testMoodleFilesBoilerplateCommentShortNotEof() {
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/short_not_eof.php');
+
+        $this->setErrors([
+            15 => 'CommentEndedTooSoon',
         ]);
         $this->setWarnings([]);
 
@@ -138,6 +151,39 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase
         $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/gnu_https.php');
 
         $this->setErrors([]);
+        $this->setWarnings([]);
+
+        $this->verifyCsResults();
+    }
+
+    /**
+     * Assert that boilerplate is found if it is not the first thing in the file.
+     */
+    public function testMoodleFilesBoilerplateCommentWrongPlace() {
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/wrong_place.php');
+
+        $this->setErrors([
+            2 => 'not found at first line',
+            9 => 'either version 3 of the License',
+        ]);
+        $this->setWarnings([]);
+
+        $this->verifyCsResults();
+    }
+
+    /**
+     * Assert that boilerplate is followed by a single newline.
+     */
+    public function testMoodleFilesBoilerplateCommentTrailingWhitespace() {
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/trailing_whitespace.php');
+
+        $this->setErrors([
+            16 => 'SingleTrailingNewLine',
+        ]);
         $this->setWarnings([]);
 
         $this->verifyCsResults();

--- a/moodle/Tests/fixtures/files/boilerplatecomment/blank.php.fixed
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/blank.php.fixed
@@ -1,12 +1,9 @@
 <?php
-
-use core\context\system;
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version N of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // Moodle is distributed in the hope that it will be useful,

--- a/moodle/Tests/fixtures/files/boilerplatecomment/short.php.fixed
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/short.php.fixed
@@ -1,12 +1,9 @@
 <?php
-
-use core\context\system;
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version N of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // Moodle is distributed in the hope that it will be useful,
@@ -15,6 +12,4 @@ use core\context\system;
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-
-class someclass { }
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.

--- a/moodle/Tests/fixtures/files/boilerplatecomment/short_empty.php.fixed
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/short_empty.php.fixed
@@ -1,12 +1,9 @@
 <?php
-
-use core\context\system;
-
-// This file is part of Moodle - http://moodle.org/
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version N of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // Moodle is distributed in the hope that it will be useful,
@@ -15,6 +12,4 @@ use core\context\system;
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-
-class someclass { }
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.

--- a/moodle/Tests/fixtures/files/boilerplatecomment/short_not_eof.php
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/short_not_eof.php
@@ -1,0 +1,17 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+
+class some_class {
+}

--- a/moodle/Tests/fixtures/files/boilerplatecomment/short_not_eof.php.fixed
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/short_not_eof.php.fixed
@@ -1,12 +1,9 @@
 <?php
-
-use core\context\system;
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version N of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // Moodle is distributed in the hope that it will be useful,
@@ -15,6 +12,7 @@ use core\context\system;
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
-class someclass { }
+class some_class {
+}

--- a/moodle/Tests/fixtures/files/boilerplatecomment/trailing_whitespace.php
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/trailing_whitespace.php
@@ -1,0 +1,17 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+

--- a/moodle/Tests/fixtures/files/boilerplatecomment/trailing_whitespace.php.fixed
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/trailing_whitespace.php.fixed
@@ -1,12 +1,9 @@
 <?php
-
-use core\context\system;
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version N of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // Moodle is distributed in the hope that it will be useful,
@@ -17,4 +14,3 @@ use core\context\system;
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-class someclass { }

--- a/moodle/Tests/fixtures/files/boilerplatecomment/trailing_whitespace_missing.php
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/trailing_whitespace_missing.php
@@ -1,12 +1,9 @@
 <?php
-
-use core\context\system;
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version N of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // Moodle is distributed in the hope that it will be useful,
@@ -16,5 +13,6 @@ use core\context\system;
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-
-class someclass { }
+    // It's not important that these lines are wrongly indented, Here
+    // we are only confirming that the Boilerplate Sniff fixed respects it.
+    class someclass { }

--- a/moodle/Tests/fixtures/files/boilerplatecomment/trailing_whitespace_missing.php.fixed
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/trailing_whitespace_missing.php.fixed
@@ -1,12 +1,9 @@
 <?php
-
-use core\context\system;
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version N of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // Moodle is distributed in the hope that it will be useful,
@@ -17,4 +14,6 @@ use core\context\system;
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-class someclass { }
+    // It's not important that these lines are wrongly indented, Here
+    // we are only confirming that the Boilerplate Sniff fixed respects it.
+    class someclass { }

--- a/moodle/Tests/fixtures/files/boilerplatecomment/wrong_place.php
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/wrong_place.php
@@ -1,0 +1,20 @@
+<?php
+
+use core\context\system;
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version N of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+class someclass { }

--- a/moodle/Tests/fixtures/files/boilerplatecomment/wrong_place.php.fixed
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/wrong_place.php.fixed
@@ -1,12 +1,9 @@
 <?php
-
-use core\context\system;
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version N of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // Moodle is distributed in the hope that it will be useful,
@@ -16,5 +13,7 @@ use core\context\system;
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+use core\context\system;
 
 class someclass { }

--- a/moodle/Tests/fixtures/files/boilerplatecomment/wrongline.php.fixed
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/wrongline.php.fixed
@@ -1,12 +1,9 @@
 <?php
-
-use core\context\system;
-
-// This file is part of Moodle - http://moodle.org/
+// This file is part of Moodle - https://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version N of the License, or
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
 // Moodle is distributed in the hope that it will be useful,


### PR DESCRIPTION
There are a few troublesome things I find about BoilerplateCommentSniff:

1. It doesn't allow you to use `declare(strict_types=1)` in the standard place - on the same line as the opening PHP tag. You have to put it directly after the Moodle comment, which is obviously valid but it's non-standard and harder to spot.
2. If you have anything at all on the line after the PHP tag, except for the Moodle boilerplate, you get 14 separate messages saying that some random token doesn't match a line of the Moodle boilerplate. I'd expect a single message saying that the boilerplate wasn't found, or at least for it only to attempt to validate comment tokens.
3. There are no fixes available

(I appreciate that the second point probably doesn't affect core development so much because all core files have the boilerplate, but it just swamps the output with noise if you have a plugin that doesn't yet have the boilerplate in any of the files.)

Could I propose this patch to improve things a bit? It:

* allows `declare()` calls on the same line as the opening PHP tag
* only checks the boilerplate for contiguous comment tokens, and bails out if it encounters any other kind of token
* provides fixes to automate inserting / fixing the boilerplate when it's found in the wrong place or incomplete

