### PR TITLE
Better integration tests, with correct exit status checks

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -63,18 +63,42 @@ jobs:
         run: ./vendor/bin/phpunit-coverage-check -t 80 clover.xml
 
       - name: Integration tests
-        if: ${{ (!cancelled()) && (runner.os == 'ubuntu-latest') }}
+        if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' }}
         run: |
-          # There is one failure (exit with error)
-          vendor/bin/phpcs --standard=moodle moodle/Tests/fixtures/integration_test_ci.php | tee output.txt || [[ $? = 1 ]]
+          # There is one failure (exit with error 2, because some are fixable).
+          expectedcode=2
+          vendor/bin/phpcs --standard=moodle moodle/Tests/fixtures/integration_test_ci.php | tee output.txt
+          exitcode="${PIPESTATUS[0]}"
+          if [[ "${exitcode}" = "${expectedcode}" ]]; then
+              echo "Ok, got expected ${exitcode} exit code."
+          else
+              echo "Error: Expected ${expectedcode}, got ${exitcode} exit code."
+              exit 1
+          fi
           grep -q  "PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY" output.txt
 
-          # The failure is fixed (exit with error)
-          vendor/bin/phpcbf --standard=moodle moodle/Tests/fixtures/integration_test_ci.php | tee output.txt || [[ $? = 1 ]]
+          # The failure is fixed (exit with error 1, because all fixable ones were fixed).
+          expectedcode=1
+          vendor/bin/phpcbf --standard=moodle moodle/Tests/fixtures/integration_test_ci.php | tee output.txt
+          exitcode="${PIPESTATUS[0]}"
+          if [[ "${exitcode}" = "${expectedcode}" ]]; then
+              echo "Ok, got expected ${exitcode} exit code."
+          else
+              echo "Error: Expected ${expectedcode}, got ${exitcode} exit code."
+              exit 1
+          fi
           grep -q "A TOTAL OF 1 ERROR WERE FIXED IN 1 FILE" output.txt
 
-          # So, there isn't any failure any more (exit without error)
-          vendor/bin/phpcs --standard=moodle moodle/Tests/fixtures/integration_test_ci.php | tee output.txt && [[ $? = 0 ]]
+          # So, there isn't any failure any more (exit without error, aka, 0)
+          expectedcode=0
+          vendor/bin/phpcs --standard=moodle moodle/Tests/fixtures/integration_test_ci.php | tee output.txt
+          exitcode="${PIPESTATUS[0]}"
+          if [[ "${exitcode}" = "${expectedcode}" ]]; then
+              echo "Ok, got expected ${exitcode} exit code."
+          else
+              echo "Error: Expected ${expectedcode}, got ${exitcode} exit code."
+              exit 1
+          fi
 
       - name: Mark cancelled jobs as failed
         if: ${{ cancelled() }}

--- a/moodle/Tests/fixtures/integration_test_ci.php
+++ b/moodle/Tests/fixtures/integration_test_ci.php
@@ -1,4 +1,3 @@
-<?php
-// phpcs:disable moodle.Files
+<?php // phpcs:disable moodle.Files,moodle.Commenting
 defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
 $arr ['wrong'] = $value;


### PR DESCRIPTION
There were a few problems with the integration checks, not properly detecting & asserting the expected exit statuses. Plus some problem using `runner.os` that uses different names (`Linux`, `Windows`, `macOS`), so switching to `matrix.os`

Now they are better checked, with some output added to explain the problem when the script runs.