### PR TITLE
Detect multiple @coversDefaultClass uses in a class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- The existing `moodle.PHPUnit.TestCaseCovers` sniff now detects multiple uses of the `@coversDefaultClass` annotation. Only one is allowed by class. 
 
 ## [v3.4.7] - 2024-05-31
 ### Added

--- a/moodle/Tests/PHPUnitTestCaseCoversTest.php
+++ b/moodle/Tests/PHPUnitTestCaseCoversTest.php
@@ -93,9 +93,18 @@ class PHPUnitTestCaseCoversTest extends MoodleCSBaseTestCase
             'CoversDefaultClass' => [
                 'fixture' => 'fixtures/phpunit/testcasecovers_coversdefaultclass.php',
                 'errors' => [
-                    8 => 'Wrong @coversDefaultClass annotation, it must be FQCN (\\ prefixed)',
-                    9 => 'TestCaseCovers.WrongMethod',
-                    10 => '@coversDefaultClass annotation, it must contain some value',
+                    8 => [
+                        'Wrong @coversDefaultClass annotation, it must be FQCN (\\ prefixed)',
+                        'Class coversdefaultclass_test has more than one @coversDefaultClass tag',
+                    ],
+                    9 => [
+                        'TestCaseCovers.WrongMethod',
+                        'TestCaseCovers.MultipleDefaultClass',
+                    ],
+                    10 => [
+                        '@coversDefaultClass annotation, it must contain some value',
+                        'Class coversdefaultclass_test has more than one @coversDefaultClass tag',
+                    ],
                     14 => 'test_something() has @coversDefaultClass tag',
                     15 => 'TestCaseCovers.DefaultClassNotAllowed',
                     16 => 'TestCaseCovers.DefaultClassNotAllowed',

--- a/moodle/Tests/fixtures/phpunit/testcasecovers_coversdefaultclass.php
+++ b/moodle/Tests/fixtures/phpunit/testcasecovers_coversdefaultclass.php
@@ -1,4 +1,4 @@
-i<?php
+<?php
 defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
 
 // Wrong @coversDefaultClass.


### PR DESCRIPTION
Pretty simple. Implemented, covered and documented.

Fixes #166.