### PR TITLE
Allow extra consecutive header lines after the official boilerplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- Fixed a recent regression by allowing to the `moodle.Files.BoilerplateComment` sniff to contain "extra" consecutive comment lines immediately after the official boilerplate ends.
 
 ## [v3.4.8] - 2024-06-14
 ### Added

--- a/moodle/Sniffs/Files/BoilerplateCommentSniff.php
+++ b/moodle/Sniffs/Files/BoilerplateCommentSniff.php
@@ -166,7 +166,22 @@ class BoilerplateCommentSniff implements Sniff
             return;
         }
 
-        $tokenptr++;
+        // Let's jump over all the extra (allowed) consecutive comments to find the first non-comment token.
+        $lastComment = $tokenptr;
+        $nextComment = $tokenptr;
+        while (($nextComment = $phpcsFile->findNext(T_COMMENT, ($nextComment + 1), null, false)) !== false) {
+            // Only \n is allowed as spacing since the previous comment line.
+            if (strpos($tokens[$nextComment - 1]['content'], "\n") === false) {
+                // Stop looking for consecutive comments, some spacing broke the sequence.
+                break;
+            }
+            if ($tokens[$nextComment]['line'] !== ($tokens[$lastComment]['line'] + 1)) {
+                // Stop looking for comments, the lines are not consecutive.
+                break;
+            }
+            $lastComment = $nextComment;
+        }
+        $tokenptr = $lastComment + 1; // Move to the last found comment + 1.
 
         $nextnonwhitespace = $phpcsFile->findNext(T_WHITESPACE, $tokenptr, null, true);
 

--- a/moodle/Tests/FilesBoilerPlateCommentTest.php
+++ b/moodle/Tests/FilesBoilerPlateCommentTest.php
@@ -48,6 +48,14 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase
         $this->setWarnings([]);
 
         $this->verifyCsResults();
+
+        // Finally, try with another comments block after the boilerplate.
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/ok3.php');
+
+        $this->setErrors([]);
+        $this->setWarnings([]);
+
+        $this->verifyCsResults();
     }
 
     public function testMoodleFilesBoilerplateCommentNoPHP() {

--- a/moodle/Tests/fixtures/files/boilerplatecomment/ok3.php
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/ok3.php
@@ -18,4 +18,6 @@
 // to put any other information. We only will require the blank line
 // after the whole boilerplate ends.
 
+// But this is already considered another comments block, valid but another,
+// so we don't require the blank line here (we have required it above).
 class someclass { }


### PR DESCRIPTION
Once the official boilerplate checks have been performed, allow the "block" to be expanded with any extra information.

As far as the block is a number of consecutive comment lines, exclusively separated by \n, that's allowed.

Note that any spacing different from \n or any non consecutive comment line will stop the sequence.

Fixes: #168