### PR TITLE
Ignore invalid method names using the Override attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- The `moodle.NamingConventions.ValidFunctionName` sniff will now ignore errors on methods employing the `#[\Override]` attribute.
+
 ## [v3.4.9] - 2024-06-19
 ### Fixed
 - Fixed a recent regression by allowing to the `moodle.Files.BoilerplateComment` sniff to contain "extra" consecutive comment lines immediately after the official boilerplate ends.

--- a/moodle/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/moodle/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -27,6 +27,7 @@
 
 namespace MoodleHQ\MoodleCS\moodle\Sniffs\NamingConventions;
 
+use MoodleHQ\MoodleCS\moodle\Util\Attributes;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
 use PHP_CodeSniffer\Util\Tokens;
@@ -107,6 +108,11 @@ class ValidFunctionNameSniff extends AbstractScopeSniff
         $methodprops    = $phpcsfile->getMethodProperties($stackptr);
         $scope          = $methodprops['scope'];
         $scopespecified = $methodprops['scope_specified'];
+
+        if (Attributes::hasOverrideAttribute($phpcsfile, $stackptr)) {
+            // This method has an `#[\Override]` attribute, so it is allowed to have a different name.
+            return;
+        }
 
         // Only lower-case accepted.
         if (

--- a/moodle/Tests/fixtures/namingconventions/validfunctionname_correct.php
+++ b/moodle/Tests/fixtures/namingconventions/validfunctionname_correct.php
@@ -64,3 +64,10 @@ return new class {
         echo 'hi';
     }
 };
+
+class example extends class_with_correct_function_names {
+    #[\Override]
+    public function childMethod(): void {
+        echo 'hi';
+    }
+}


### PR DESCRIPTION
This is useful where we must override methods in third-party libraries.