### PR TITLE
Ignore anonymous class docblocks if they have a parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 ## [Unreleased]
 ### Changed
 - The `moodle.NamingConventions.ValidFunctionName` sniff will now ignore errors on methods employing the `#[\Override]` attribute.
+- The `moodle.Commenting.MissingDocblock` sniff no longer warns about missing docs on non-global anonymous classes, for example those written as an instance class in a unit test.
 
 ## [v3.4.9] - 2024-06-19
 ### Fixed

--- a/moodle/Sniffs/Commenting/MissingDocblockSniff.php
+++ b/moodle/Sniffs/Commenting/MissingDocblockSniff.php
@@ -83,6 +83,11 @@ class MissingDocblockSniff implements Sniff
                 // Skip methods of classes, traits and interfaces.
                 continue;
             }
+            if ($token['code'] === T_ANON_CLASS && !empty($token['conditions'])) {
+                // Skip anonymous classes.
+                continue;
+            }
+
             $artifactCount++;
 
             if ($token['code'] === T_FUNCTION) {

--- a/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
@@ -199,6 +199,31 @@ class MissingDocblockSniffTest extends MoodleCSBaseTestCase
                 'warnings' => [
                 ],
             ],
+            'Anonymous class as only class in file (documented)' => [
+                'fixture' => 'entire_anonymous_class_documented',
+                'fixtureFilename' => null,
+                'errors' => [
+                ],
+                'warnings' => [
+                ],
+            ],
+            'Anonymous class as only class in file (undocumented)' => [
+                'fixture' => 'entire_anonymous_class',
+                'fixtureFilename' => null,
+                'errors' => [
+                    5 => 'Missing docblock for class anonymous class',
+                ],
+                'warnings' => [
+                ],
+            ],
+            'Anonymous class as member of method' => [
+                'fixture' => 'nested_anonymous_class',
+                'fixtureFilename' => null,
+                'errors' => [
+                ],
+                'warnings' => [
+                ],
+            ],
         ];
 
         if (version_compare(PHP_VERSION, '8.0.0') >= 0) {

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/entire_anonymous_class.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/entire_anonymous_class.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+return new class() extends \stdClass {};

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/entire_anonymous_class_documented.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/entire_anonymous_class_documented.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+/**
+ * Class level docblock.
+ */
+return new class() extends \stdClass {};

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/nested_anonymous_class.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/nested_anonymous_class.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+/**
+ * Class level docblock.
+ */
+class class_with_anonymous_class_in_method {
+    /**
+     * Documented method.
+     */
+    public function test(): string {
+        return new class() extends \stdClass {};
+    }
+}


### PR DESCRIPTION
There's usually little need to document an anonymous class when it is part of another method.