### PR TITLE
Fixes #174. Insert boilerplate correctly where comment on first line.

### DIFF
--- a/moodle/Sniffs/Files/BoilerplateCommentSniff.php
+++ b/moodle/Sniffs/Files/BoilerplateCommentSniff.php
@@ -233,8 +233,16 @@ class BoilerplateCommentSniff implements Sniff
 
     private function insertBoilerplate(File $file, int $stackptr): void
     {
-        $prefix = substr($file->getTokens()[$stackptr]['content'], -1) === "\n" ? '' : "\n";
-        $file->fixer->addContent($stackptr, $prefix . implode("\n", $this->fullComment()) . "\n");
+        $token = $file->getTokens()[$stackptr];
+        $paddedComment = implode("\n", $this->fullComment()) . "\n";
+
+        if ($token['code'] === T_OPEN_TAG) {
+            $replacement = trim($token['content']) . "\n" . $paddedComment;
+            $file->fixer->replaceToken($stackptr, $replacement);
+        } else {
+            $prefix = substr($token['content'], -1) === "\n" ? '' : "\n";
+            $file->fixer->addContent($stackptr, $prefix . $paddedComment);
+        }
     }
 
     private function moveBoilerplate(File $file, int $start, int $target): void

--- a/moodle/Tests/FilesBoilerPlateCommentTest.php
+++ b/moodle/Tests/FilesBoilerPlateCommentTest.php
@@ -212,4 +212,32 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase
 
         $this->verifyCsResults();
     }
+
+    public function testMoodleFilesBoilerplateCommentFirstlineComment() {
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/firstline_comment.php');
+
+        $this->setErrors([
+            1 => 'NoBoilerplateComment',
+        ]);
+
+        $this->setWarnings([]);
+
+        $this->verifyCsResults();
+    }
+
+    public function testMoodleFilesBoilerplateCommentWithPhpcsTag() {
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/with_phpcs_tag.php');
+
+        $this->setErrors([
+            1 => 'NoBoilerplateComment',
+        ]);
+
+        $this->setWarnings([]);
+
+        $this->verifyCsResults();
+    }
 }

--- a/moodle/Tests/fixtures/files/boilerplatecomment/firstline_comment.php
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/firstline_comment.php
@@ -1,0 +1,4 @@
+<?php // Some comment on first line.
+
+class test {
+}

--- a/moodle/Tests/fixtures/files/boilerplatecomment/firstline_comment.php.fixed
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/firstline_comment.php.fixed
@@ -1,0 +1,19 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+// Some comment on first line.
+
+class test {
+}

--- a/moodle/Tests/fixtures/files/boilerplatecomment/with_phpcs_tag.php
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/with_phpcs_tag.php
@@ -1,0 +1,1 @@
+<?php      // phpcs:enable

--- a/moodle/Tests/fixtures/files/boilerplatecomment/with_phpcs_tag.php.fixed
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/with_phpcs_tag.php.fixed
@@ -1,0 +1,15 @@
+<?php      // phpcs:enable
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
This fixes #174 

I've added a test fixture to make sure it works as expected. I'd rather there was a blank line between the boilerplate and the original comment but I can't find a way to do this that doesn't either break other tests, or require a lot of complicated code, so hopefully what it's doing is acceptable.