### PR TITLE
Fixes #176. Match blank boilerplate lines correctly.

### DIFF
--- a/moodle/Sniffs/Files/BoilerplateCommentSniff.php
+++ b/moodle/Sniffs/Files/BoilerplateCommentSniff.php
@@ -288,6 +288,11 @@ class BoilerplateCommentSniff implements Sniff
      */
     private function regexForLine(string $line): string
     {
+        // We need to match the blank lines in their entirety.
+        if ($line === '//') {
+            return '/^\/\/$/';
+        }
+
         return str_replace(
             ['Moodle', 'https\\:'],
             ['.*', 'https?\\:'],

--- a/moodle/Tests/FilesBoilerPlateCommentTest.php
+++ b/moodle/Tests/FilesBoilerPlateCommentTest.php
@@ -240,4 +240,26 @@ class FilesBoilerPlateCommentTest extends MoodleCSBaseTestCase
 
         $this->verifyCsResults();
     }
+
+    public function testMoodleFilesBoilerplateCommentMissingLines() {
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.Files.BoilerplateComment');
+        $this->setFixture(__DIR__ . '/fixtures/files/boilerplatecomment/missing_lines.php');
+
+        $this->setErrors([
+            3 => 'moodle.Files.BoilerplateComment.WrongLine',
+            4 => 'moodle.Files.BoilerplateComment.WrongLine',
+            5 => 'moodle.Files.BoilerplateComment.WrongLine',
+            6 => 'moodle.Files.BoilerplateComment.WrongLine',
+            7 => 'moodle.Files.BoilerplateComment.WrongLine',
+            8 => 'moodle.Files.BoilerplateComment.WrongLine',
+            9 => 'moodle.Files.BoilerplateComment.WrongLine',
+            10 => 'moodle.Files.BoilerplateComment.WrongLine',
+            11 => 'moodle.Files.BoilerplateComment.WrongLine',
+            12 => ['moodle.Files.BoilerplateComment.WrongLine', 'moodle.Files.BoilerplateComment.CommentEndedTooSoon'],
+        ]);
+        $this->setWarnings([]);
+
+        $this->verifyCsResults();
+    }
 }

--- a/moodle/Tests/fixtures/files/boilerplatecomment/missing_lines.php
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/missing_lines.php
@@ -1,0 +1,12 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.

--- a/moodle/Tests/fixtures/files/boilerplatecomment/missing_lines.php.fixed
+++ b/moodle/Tests/fixtures/files/boilerplatecomment/missing_lines.php.fixed
@@ -1,0 +1,15 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
This patch fixes an issue that contributes to #176 where lines of the boilerplate that should be blank are not identified as wrong if they have text in them. 

This is because we are only checking that the lines start with the expected text. I'm not sure why this is but it was this way in the original code before I added the fixes.

I think this fixes #176 in a way, although there is still a weird chain of fixing going on when there's a CRLF in the opening PHP tag. I'll add some more to that issue about it just in case it comes up again.