### PR TITLE
Bump to phpcs 3.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- Update composer dependencies to current versions, notably `PHP_CodeSniffer` (3.10.2)
+
 ## [v3.4.10] - 2024-07-04
 ### Changed
 - The `moodle.NamingConventions.ValidFunctionName` sniff will now ignore errors on methods employing the `#[\Override]` attribute.

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=7.4.0",
         "ext-json": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
-        "squizlabs/php_codesniffer": "^3.10.1",
+        "squizlabs/php_codesniffer": "^3.10.2",
         "phpcsstandards/phpcsextra": "^1.2.1",
         "phpcompatibility/php-compatibility": "dev-develop#96072c30"
     },


### PR DESCRIPTION
I've also reviewed other dependencies and only PHPCompatibility is slightly "old" (May 2024), so decided not to bump it.