### PR TITLE
Add test for multiline attributes for MissingDocblockSniff on methods outside of classes

### DIFF
--- a/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
@@ -231,10 +231,11 @@ class MissingDocblockSniffTest extends MoodleCSBaseTestCase
                 'fixture' => 'docblock_with_multiline_attributes',
                 'fixtureFilename' => null,
                 'errors' => [
-                    59 => 'Missing docblock for class class_multiline_attribute_space_between',
-                    69 => 'Missing docblock for function method_multiline_attribute_space_between',
-                    81 => 'Missing docblock for interface interface_multiline_attribute_space_between',
-                    92 => 'Missing docblock for trait trait_multiline_attribute_space_between',
+                    69 => 'Missing docblock for class class_multiline_attribute_space_between',
+                    79 => 'Missing docblock for function method_multiline_attribute_space_between',
+                    91 => 'Missing docblock for function single_method_multiline_attribute_space_between',
+                    102 => 'Missing docblock for interface interface_multiline_attribute_space_between',
+                    113 => 'Missing docblock for trait trait_multiline_attribute_space_between',
                 ],
                 'warnings' => [],
             ];

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/docblock_with_multiline_attributes.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/docblock_with_multiline_attributes.php
@@ -28,6 +28,16 @@ class class_multiline_attribute {
     }
 }
 
+/*
+ * Function with multiline attributes.
+ */
+#[someattribute(
+    attr1: 'asdf',
+    attr2: 'asdf',
+)]
+function single_method_multiline_attribute(): void {
+}
+
 /**
  * Interface with multiline attributes.
  */
@@ -68,6 +78,17 @@ class class_multiline_attribute_space_between {
     )]
     function method_multiline_attribute_space_between(): void {
     }
+}
+
+/*
+ * Function with multiline attributes and space between.
+ */
+
+#[someattribute(
+    attr1: 'asdf',
+    attr2: 'asdf',
+)]
+function single_method_multiline_attribute_space_between(): void {
 }
 
 /**


### PR DESCRIPTION
This are two test cases for #185.