### PR TITLE
Promote `Generic.Arrays.DisallowLongArraySyntax` to error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
   - `phpcsstandards/phpcsextra` to 1.4.0
   - `dealerdirect/phpcodesniffer-composer-installer` to 1.1.1
 - A number of legacy Moodle rules have been removed. See MDLSITE-7597 for further information.
+- The `Generic.Arrays.DisallowLongArraySyntax` rule has been changed to an error as planned in #58.
 
 ## [v3.4.11] - 2025-06-26
 ### Fixed

--- a/moodle-extra/ruleset.xml
+++ b/moodle-extra/ruleset.xml
@@ -9,11 +9,6 @@
     <!-- Extend the standard Moodle coding style -->
     <rule ref="moodle"/>
 
-    <!-- Best practice improvements -->
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax">
-        <type>error</type>
-    </rule>
-
     <!--
         Moodle contains a lot of code which pre-dates PHP 7.1 and did not support constant visibility.
         We do not warn about these in the `moodle` standard, but we do want to detect them here with the view to warning about them in the future.

--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -58,7 +58,9 @@
     <exclude name="moodle.NamingConventions.ValidVariableName.VariableNameLowerCase" phpcbf-only="true" />
 
     <!-- Disallow the Long Array syntax `array()` -->
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax">
+        <type>error</type>
+    </rule>
 
     <!--
         Trailing commas in multi-line Arrays.


### PR DESCRIPTION
Fixes #58