### PR TITLE
Add missing valid tags for @var blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- The `moodle.Commenting.VariableComment` sniff now accepts the following tags as valid on a `@var`:
+  - `@since`
+  - `@link`
+  - `@deprecated`
 ## [v3.5.0] - 2025-07-17
 ### Changed
 - Bumped dependencies for:

--- a/moodle/Sniffs/Commenting/VariableCommentSniff.php
+++ b/moodle/Sniffs/Commenting/VariableCommentSniff.php
@@ -36,6 +36,19 @@ use PHPCSUtils\Utils\ObjectDeclarations;
 class VariableCommentSniff extends AbstractVariableSniff
 {
     /**
+     * Tags which are allowed in a member variable comment.
+     *
+     * @var array
+     */
+    private static $allowedtags = [
+        '@var',
+        '@see',
+        '@link',
+        '@deprecated',
+        '@since',
+    ];
+
+    /**
      * Called to process class member vars.
      *
      * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
@@ -102,7 +115,8 @@ class VariableCommentSniff extends AbstractVariableSniff
                     $error = 'Content missing for @see tag in member variable comment';
                     $phpcsFile->addError($error, $tag, 'EmptySees');
                 }
-            } else {
+            } elseif (in_array($tokens[$tag]['content'], self::$allowedtags, true) === false) {
+                // If the tag is not in the allowed list, then it is an error.
                 $error = '%s tag is not allowed in member variable comment';
                 $data = [$tokens[$tag]['content']];
                 $phpcsFile->addWarning($error, $tag, 'TagNotAllowed', $data);

--- a/moodle/Tests/Sniffs/Commenting/VariableCommentSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/VariableCommentSniffTest.php
@@ -60,7 +60,7 @@ class VariableCommentSniffTest extends MoodleCSBaseTestCase
                     90 => 'The @var tag must be the first tag in a member variable comment',
                 ],
                 'warnings' => [
-                    82 => '@deprecated tag is not allowed in member variable comment',
+                    82 => '@throws tag is not allowed in member variable comment',
                 ],
             ],
             'Single line variable declarations' => [
@@ -98,6 +98,13 @@ class VariableCommentSniffTest extends MoodleCSBaseTestCase
                 'warnings' => [
                 ],
             ],
+            'Other allowed tags' => [
+                'fixture' => 'other_allowed_tags',
+                'errors' => [
+                ],
+                'warnings' => [
+                ],
+            ],
         ];
 
         if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
@@ -110,7 +117,7 @@ class VariableCommentSniffTest extends MoodleCSBaseTestCase
                     20 => 'The @var tag must be the first tag in a member variable commen',
                 ],
                 'warnings' => [
-                    19 => '@deprecated tag is not allowed in member variable comment',
+                    19 => '@throws tag is not allowed in member variable comment',
                 ],
             ];
         }
@@ -125,7 +132,7 @@ class VariableCommentSniffTest extends MoodleCSBaseTestCase
                     20 => 'The @var tag must be the first tag in a member variable commen',
                 ],
                 'warnings' => [
-                    19 => '@deprecated tag is not allowed in member variable comment',
+                    19 => '@throws tag is not allowed in member variable comment',
                 ],
             ];
         }

--- a/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/constructor_property_promotion.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/constructor_property_promotion.php
@@ -16,7 +16,7 @@ class cpp_only {
         /**
          * The page to do it on.
          *
-         * @deprecated
+         * @throws \Exception
          * @var \moodle_page
          */
         public \moodle_page $page,

--- a/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/constructor_property_promotion.php.fixed
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/constructor_property_promotion.php.fixed
@@ -16,7 +16,7 @@ class cpp_only {
         /**
          * The page to do it on.
          *
-         * @deprecated
+         * @throws \Exception
          * @var \moodle_page
          */
         public \moodle_page $page,

--- a/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/constructor_property_promotion_readonly.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/constructor_property_promotion_readonly.php
@@ -16,7 +16,7 @@ class cpp_only {
         /**
          * The page to do it on.
          *
-         * @deprecated
+         * @throws \Exception
          * @var \moodle_page
          */
         public readonly \moodle_page $page,

--- a/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/constructor_property_promotion_readonly.php.fixed
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/constructor_property_promotion_readonly.php.fixed
@@ -16,7 +16,7 @@ class cpp_only {
         /**
          * The page to do it on.
          *
-         * @deprecated
+         * @throws \Exception
          * @var \moodle_page
          */
         public readonly \moodle_page $page,

--- a/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/multiline.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/multiline.php
@@ -79,7 +79,7 @@ class class_only {
      * Other tag (not supported).
      *
      * @var string
-     * @deprecated Since 4.4.0
+     * @throws \Exception
      */
     protected string $hasothertag;
 

--- a/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/multiline.php.fixed
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/multiline.php.fixed
@@ -79,7 +79,7 @@ class class_only {
      * Other tag (not supported).
      *
      * @var string
-     * @deprecated Since 4.4.0
+     * @throws \Exception
      */
     protected string $hasothertag;
 

--- a/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/other_allowed_tags.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/VariableComment/other_allowed_tags.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHPUnit;
+
+class other_allowed_tags {
+    /**
+     * @var int Some deprecated value.
+     * @deprecated This variable is deprecated and will be removed in future versions.
+     */
+    protected int $deprecatedvar;
+
+    /**
+     * @var int Some deprecated value.
+     * @since Version 1.0.0
+     */
+    protected int $sincevar;
+
+    /**
+     * @var int Some deprecated value.
+     * @link https://example.com
+     */
+    protected int $linkedvar;
+}


### PR DESCRIPTION
It is perfectly acceptable to:

- provide a @link to elsewhere;
- declare when a var was made available with the @since tag
- declare that a var was @deprecated