### PR TITLE
Remove deprecated elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 - Dropped the following deprecated sniffs:
   - `Squiz.Classes.DuplicateProperty` - JS only
   - `Generic.Functions.CallTimePassByReference` - PHP support dropped in PHP 5.4
+### Fixed
+- Update incorrect use of legacy ruleset format.
 
 ## [v3.5.2] - 2025-08-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format of this change log follows the advice given at [Keep a CHANGELOG](htt
 - Automated fixes for the following sniffs were removed as they can cause unwanted changes:
    - `moodle.NamingConventions.ValidFunctionName`
    - `moodle.NamingConventions.ValidVariableName`
+### Changed
+- Dropped the following deprecated sniffs:
+  - `Squiz.Classes.DuplicateProperty` - JS only
+  - `Generic.Functions.CallTimePassByReference` - PHP support dropped in PHP 5.4
 
 ## [v3.5.2] - 2025-08-14
 ### Fixed

--- a/moodle/Tests/MoodleStandardTest.php
+++ b/moodle/Tests/MoodleStandardTest.php
@@ -717,31 +717,6 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     }
 
     /**
-     * Test call time pass by reference.
-     *
-     * @covers \PHPCompatibility\Sniffs\Syntax\ForbiddenCallTimePassByReferenceSniff
-     */
-    public function testPHPCompatibilitySyntaxForbiddenCallTimePassByReference() {
-
-        // Define the standard, sniff and fixture to use.
-        $this->setStandard('moodle');
-        $this->setSniff('PHPCompatibility.Syntax.ForbiddenCallTimePassByReference');
-        $this->setFixture(__DIR__ . '/fixtures/phpcompatibility_php_forbiddencalltimepassbyreference.php');
-
-        // Define expected results (errors and warnings). Format, array of:
-        // - line => number of problems,  or
-        // - line => array of contents for message / source problem matching.
-        // - line => string of contents for message / source problem matching (only 1).
-        $this->setErrors([
-            6 => ['call-time pass-by-reference is deprecated'],
-            7 => ['@Source: PHPCompat']]);
-        $this->setWarnings([]);
-
-        // Let's do all the hard work!
-        $this->verifyCsResults();
-    }
-
-    /**
      * Test variable naming standards
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\NamingConventions\ValidVariableNameSniff

--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -83,7 +83,6 @@
 
     <rule ref="Generic.ControlStructures.InlineControlStructure"/>
 
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
 
     <rule ref="Generic.NamingConventions.ConstructorName"/>
@@ -94,7 +93,6 @@
         </properties>
     </rule>
 
-    <rule ref="Squiz.Classes.DuplicateProperty"/>
     <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
     <rule ref="Squiz.Classes.SelfMemberReference"/>
 

--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -89,7 +89,9 @@
 
     <rule ref="Generic.WhiteSpace.ScopeIndent">
         <properties>
-            <property name="ignoreIndentationTokens" type="array" value="T_CLOSE_TAG"/>
+            <property name="ignoreIndentationTokens" type="array">
+                <element value="T_CLOSE_TAG"/>
+            </property>
         </properties>
     </rule>
 


### PR DESCRIPTION
* Two upstream PHPCS sniffs have been deprecated as they are no longer supported by recent versions of PHP
* There is also a rule format change

Fixes #210