### PR TITLE
Remove phpcompat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 The format of this change log follows the advice given at [Keep a CHANGELOG](https://keepachangelog.com).
 
+## [Unreleased]
+### Removed
+- Support for PHPCompatibility until moodle-cs is upgraded to support PHP_CodeSniffer version 4.
+
 ## [v3.6.0] - 2025-09-09
 
 ## [v3.6.0] - 2025-09-09

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
         "ext-json": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.1.1",
         "squizlabs/php_codesniffer": "^3.13.2",
-        "phpcsstandards/phpcsextra": "^1.4.0",
-        "phpcompatibility/php-compatibility": "dev-develop#5e207bcc"
+        "phpcsstandards/phpcsextra": "^1.4.0"
     },
     "config": {
         "allow-plugins": {

--- a/moodle/Tests/MoodleStandardTest.php
+++ b/moodle/Tests/MoodleStandardTest.php
@@ -692,31 +692,6 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     }
 
     /**
-     * Test external sniff incorporated to moodle standard.
-     *
-     * @covers \PHPCompatibility\Sniffs\FunctionUse\RemovedFunctionsSniff
-     */
-    public function testPHPCompatibilityFunctionUseRemovedFunctions() {
-
-        // Define the standard, sniff and fixture to use.
-        $this->setStandard('moodle');
-        $this->setSniff('PHPCompatibility.FunctionUse.RemovedFunctions');
-        $this->setFixture(__DIR__ . '/fixtures/phpcompatibility_php_deprecatedfunctions.php');
-
-        // Define expected results (errors and warnings). Format, array of:
-        // - line => number of problems,  or
-        // - line => array of contents for message / source problem matching.
-        // - line => string of contents for message / source problem matching (only 1).
-        $this->setErrors([
-            5 => ['Function ereg_replace', 'Use call_user_func() instead', '@Source: PHPCompat'],
-        ]);
-        $this->setWarnings([]);
-
-        // Let's do all the hard work!
-        $this->verifyCsResults();
-    }
-
-    /**
      * Test variable naming standards
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\NamingConventions\ValidVariableNameSniff

--- a/moodle/Tests/bootstrap.php
+++ b/moodle/Tests/bootstrap.php
@@ -19,4 +19,3 @@ $root = dirname(dirname(__DIR__));
 
 require_once("{$root}/vendor/autoload.php");
 require_once("{$root}/vendor/squizlabs/php_codesniffer/tests/bootstrap.php");
-require_once("{$root}/vendor/phpcompatibility/php-compatibility/PHPCSAliases.php");

--- a/moodle/ruleset.xml
+++ b/moodle/ruleset.xml
@@ -12,7 +12,7 @@
     <!--
         Add the complete PHPCompatibility standard to warn about features of unsupported PHP versions.
     -->
-    <rule ref="PHPCompatibility" />
+    <!-- <rule ref="PHPCompatibility" /> -->
 
     <!--
         Include the PSR-12 ruleset with relevant Moodle exclusions

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -33,14 +33,4 @@
     <rule ref="NormalizedArrays.Arrays.CommaAfterLast">
         <exclude name="NormalizedArrays.Arrays.CommaAfterLast.MissingMultiLineCloserSameLine" />
     </rule>
-
-    <!--PHPCompatibility configuration-->
-    <rule ref="./vendor/phpcompatibility/php-compatibility/PHPCompatibility/ruleset.xml"/>
-    <config name="testVersion" value="7.4-"/>
-
-    <!-- These are false positives because CodeSniffer creates them when needed.
-        TODO: Delete this once we raise minimum requirements to PHP 8.0. -->
-    <rule ref="PHPCompatibility.Constants.NewConstants">
-        <exclude name="PHPCompatibility.Constants.NewConstants.newConstants.t_enumFound"/>
-    </rule>
 </ruleset>


### PR DESCRIPTION
We need to remove phpcompat for the moment.

We have quite a few failures when upgrading to phpcs 4 and I don't have time to address them at the moment.