### PR TITLE
Improve PHPDoc Types

### DIFF
--- a/moodle/Sniffs/Commenting/CategorySniff.php
+++ b/moodle/Sniffs/Commenting/CategorySniff.php
@@ -32,6 +32,8 @@ class CategorySniff implements Sniff
 {
     /**
      * Register for open tag (only process once per file).
+     *
+     * @return (int|string)[]
      */
     public function register() {
         return [
@@ -44,6 +46,7 @@ class CategorySniff implements Sniff
      *
      * @param File $phpcsFile The file being scanned.
      * @param int $stackPtr The position in the stack.
+     * @return int|null
      */
     public function process(File $phpcsFile, $stackPtr) {
         $docPtr = Docblocks::getDocBlockPointer($phpcsFile, $stackPtr);

--- a/moodle/Sniffs/Commenting/ConstructorReturnSniff.php
+++ b/moodle/Sniffs/Commenting/ConstructorReturnSniff.php
@@ -32,6 +32,8 @@ class ConstructorReturnSniff implements Sniff
 {
     /**
      * Register for class tags.
+     *
+     * @return (int|string)[]
      */
     public function register() {
 
@@ -45,6 +47,7 @@ class ConstructorReturnSniff implements Sniff
      *
      * @param File $phpcsFile The file being scanned.
      * @param int $stackPtr The position in the stack.
+     * @return int|null
      */
     public function process(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();

--- a/moodle/Sniffs/Commenting/DocblockDescriptionSniff.php
+++ b/moodle/Sniffs/Commenting/DocblockDescriptionSniff.php
@@ -35,6 +35,8 @@ class DocblockDescriptionSniff implements Sniff
 {
     /**
      * Register for open tag (only process once per file).
+     *
+     * @return (int|string)[]
      */
     public function register() {
         return [
@@ -47,6 +49,7 @@ class DocblockDescriptionSniff implements Sniff
      *
      * @param File $phpcsFile The file being scanned.
      * @param int $stackPtr The position in the stack.
+     * @return int|null
      */
     public function process(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();

--- a/moodle/Sniffs/Commenting/FileExpectedTagsSniff.php
+++ b/moodle/Sniffs/Commenting/FileExpectedTagsSniff.php
@@ -52,6 +52,8 @@ class FileExpectedTagsSniff implements Sniff
 
     /**
      * Register for open tag (only process once per file).
+     *
+     * @return (int|string)[]
      */
     public function register() {
         return [
@@ -64,6 +66,7 @@ class FileExpectedTagsSniff implements Sniff
      *
      * @param File $phpcsFile The file being scanned.
      * @param int $stackPtr The position in the stack.
+     * @return int|null
      */
     public function process(File $phpcsFile, $stackPtr) {
         // Get the stack pointer for the file-level docblock.

--- a/moodle/Sniffs/Commenting/MissingDocblockSniff.php
+++ b/moodle/Sniffs/Commenting/MissingDocblockSniff.php
@@ -45,6 +45,8 @@ class MissingDocblockSniff implements Sniff
 
     /**
      * Register for open tag (only process once per file).
+     *
+     * @return (int|string)[]
      */
     public function register() {
         return [
@@ -57,6 +59,7 @@ class MissingDocblockSniff implements Sniff
      *
      * @param File $phpcsFile The file being scanned.
      * @param int $stackPtr The position in the stack.
+     * @return int|null
      */
     public function process(File $phpcsFile, $stackPtr) {
         $this->processScopes($phpcsFile, $stackPtr);

--- a/moodle/Sniffs/Commenting/PackageSniff.php
+++ b/moodle/Sniffs/Commenting/PackageSniff.php
@@ -33,6 +33,8 @@ class PackageSniff implements Sniff
 {
     /**
      * Register for open tag (only process once per file).
+     *
+     * @return (int|string)[]
      */
     public function register() {
         return [
@@ -45,6 +47,7 @@ class PackageSniff implements Sniff
      *
      * @param File $phpcsFile The file being scanned.
      * @param int $stackPtr The position in the stack.
+     * @return int|null
      */
     public function process(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();
@@ -90,7 +93,7 @@ class PackageSniff implements Sniff
      *
      * @param File $phpcsFile
      * @param int $stackPtr
-     * @param array $docblock
+     * @param int $docPtr
      * @return bool Whether any package tag was found, whether or not it was correct
      */
     protected function checkDocblock(

--- a/moodle/Sniffs/Commenting/TodoCommentSniff.php
+++ b/moodle/Sniffs/Commenting/TodoCommentSniff.php
@@ -49,6 +49,7 @@ class TodoCommentSniff implements Sniff
      * - '(MDL|CONTRIB)-[0-9]+': A Moodle core or plugin issue is required.
      * - 'https://': Any URL is required.
      * - '' (empty string or null): No check is done.
+     * @var string|null
      */
     public ?string $commentRequiredRegex = 'MDL-[0-9]+';
 

--- a/moodle/Sniffs/Commenting/ValidTagsSniff.php
+++ b/moodle/Sniffs/Commenting/ValidTagsSniff.php
@@ -32,6 +32,8 @@ class ValidTagsSniff implements Sniff
 {
     /**
      * Register for open tag (only process once per file).
+     *
+     * @return (int|string)[]
      */
     public function register() {
         return [
@@ -44,6 +46,7 @@ class ValidTagsSniff implements Sniff
      *
      * @param File $phpcsFile The file being scanned.
      * @param int $stackPtr The position in the stack.
+     * @return int|null
      */
     public function process(File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();

--- a/moodle/Sniffs/Commenting/VariableCommentSniff.php
+++ b/moodle/Sniffs/Commenting/VariableCommentSniff.php
@@ -172,8 +172,8 @@ class VariableCommentSniff extends AbstractVariableSniff
     /**
      * Processes normal variables within a method.
      *
-     * @param File $file The file where this token was found.
-     * @param int $stackptr The position where the token was found.
+     * @param File $phpcsFile The file where this token was found.
+     * @param int $stackPtr The position where the token was found.
      *
      * @return void
      */

--- a/moodle/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/moodle/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -35,8 +35,11 @@ class ControlSignatureSniff extends AbstractPatternSniff
         parent::__construct(true);
     }
 
-    /** @var array A list of tokenizers this sniff supports. */
-
+    /**
+     * Returns the patterns that should be checked.
+     *
+     * @return string[]
+     */
     protected function getPatterns() {
         return [
             'try {EOL...} catch (...) {EOL',

--- a/moodle/Sniffs/Files/MoodleInternalSniff.php
+++ b/moodle/Sniffs/Files/MoodleInternalSniff.php
@@ -34,6 +34,8 @@ class MoodleInternalSniff implements Sniff
 {
     /**
      * Register for open tag (only process once per file).
+     *
+     * @return (int|string)[]
      */
     public function register() {
         return [T_OPEN_TAG];
@@ -45,6 +47,7 @@ class MoodleInternalSniff implements Sniff
      *
      * @param File $file The file being scanned.
      * @param int $pointer The position in the stack.
+     * @return int|null
      */
     public function process(File $file, $pointer) {
         // Guess moodle root, so we can do better dispensations below.

--- a/moodle/Sniffs/Files/RequireLoginSniff.php
+++ b/moodle/Sniffs/Files/RequireLoginSniff.php
@@ -33,6 +33,8 @@ class RequireLoginSniff implements Sniff
     public $ignorewhendefined = ['NO_MOODLE_COOKIES', 'CLI_SCRIPT', 'ABORT_AFTER_CONFIG'];
     /**
      * Register for open tag (only process once per file).
+     *
+     * @return (int|string)[]
      */
     public function register() {
         return [T_OPEN_TAG];
@@ -43,6 +45,7 @@ class RequireLoginSniff implements Sniff
      *
      * @param File $file The file being scanned.
      * @param int $pointer The position in the stack.
+     * @return int|null
      */
     public function process(File $file, $pointer) {
         // We only want to do this once per file.

--- a/moodle/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/moodle/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -49,7 +49,7 @@ class DeprecatedFunctionsSniff extends GenericDeprecatedFunctionsSniff
     /**
      * If true, an error will be thrown; otherwise a warning.
      *
-     * @var boolean
+     * @var bool
      */
     public $error = false; // Consider deprecations just warnings.
 

--- a/moodle/Sniffs/PHPUnit/ParentSetUpTearDownSniff.php
+++ b/moodle/Sniffs/PHPUnit/ParentSetUpTearDownSniff.php
@@ -47,6 +47,8 @@ class ParentSetUpTearDownSniff implements Sniff
 
     /**
      * Register for open tag (only process once per file).
+     *
+     * @return (int|string)[]
      */
     public function register(): array {
         return [T_OPEN_TAG];
@@ -57,8 +59,9 @@ class ParentSetUpTearDownSniff implements Sniff
      *
      * @param File $phpcsFile The file being scanned.
      * @param int $stackPtr The position in the stack.
+     * @return int|null
      */
-    public function process(File $phpcsFile, $stackPtr): void {
+    public function process(File $phpcsFile, $stackPtr) {
 
         // Before starting any check, let's look for various things.
 

--- a/moodle/Sniffs/PHPUnit/TestCaseCoversSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseCoversSniff.php
@@ -32,6 +32,8 @@ class TestCaseCoversSniff extends AbstractTestCaseSniff
 {
     /**
      * Register for open tag (only process once per file).
+     *
+     * @return (int|string)[]
      */
     public function register() {
         return [T_OPEN_TAG];
@@ -42,6 +44,7 @@ class TestCaseCoversSniff extends AbstractTestCaseSniff
      *
      * @param File $file The file being scanned.
      * @param int $pointer The position in the stack.
+     * @return int|null
      */
     public function process(File $file, $pointer) {
         if (!$this->shouldCheckFile($file)) {

--- a/moodle/Sniffs/PHPUnit/TestCaseNamesSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseNamesSniff.php
@@ -46,6 +46,8 @@ class TestCaseNamesSniff implements Sniff
 
     /**
      * Register for open tag (only process once per file).
+     *
+     * @return (int|string)[]
      */
     public function register() {
         return [T_OPEN_TAG];
@@ -57,6 +59,7 @@ class TestCaseNamesSniff implements Sniff
      *
      * @param File $file The file being scanned.
      * @param int $pointer The position in the stack.
+     * @return int|null
      */
     public function process(File $file, $pointer) {
         // Before starting any check, let's look for various things.
@@ -312,7 +315,7 @@ class TestCaseNamesSniff implements Sniff
      *
      * So we fill them here when it's detected that we are running PHPUnit.
      */
-    private function prepareCachesForPHPUnit() {
+    private function prepareCachesForPHPUnit(): void {
         $this->foundClasses['local_codechecker\testcasenames_duplicate_exists'][] = [
             'file' => 'phpunit_fake_exists',
             'line' => -999,

--- a/moodle/Sniffs/PHPUnit/TestCaseProviderSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestCaseProviderSniff.php
@@ -49,6 +49,8 @@ class TestCaseProviderSniff extends AbstractTestCaseSniff
 
     /**
      * Register for open tag (only process once per file).
+     *
+     * @return (int|string)[]
      */
     public function register(): array
     {
@@ -62,8 +64,9 @@ class TestCaseProviderSniff extends AbstractTestCaseSniff
      *
      * @param File $file The file being scanned.
      * @param int $pointer The position in the stack.
+     * @return int|null
      */
-    public function process(File $file, $pointer): void
+    public function process(File $file, $pointer)
     {
         if (!$this->shouldCheckFile($file)) {
             // Nothing to check.

--- a/moodle/Sniffs/PHPUnit/TestReturnTypeSniff.php
+++ b/moodle/Sniffs/PHPUnit/TestReturnTypeSniff.php
@@ -33,6 +33,8 @@ class TestReturnTypeSniff implements Sniff
 {
     /**
      * Register for open tag (only process once per file).
+     *
+     * @return (int|string)[]
      */
     public function register() {
         return [
@@ -45,6 +47,7 @@ class TestReturnTypeSniff implements Sniff
      *
      * @param File $file The file being scanned.
      * @param int $pointer The position in the stack.
+     * @return int|null
      */
     public function process(File $file, $pointer)
     {

--- a/moodle/Tests/MoodleCSBaseTestCase.php
+++ b/moodle/Tests/MoodleCSBaseTestCase.php
@@ -307,7 +307,7 @@ abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase
      *
      * @param array $errors error results produced by the CS execution.
      */
-    private function verifyErrors($errors) {
+    private function verifyErrors($errors): void {
         if (!is_array($errors)) {
             $this->fail('Unexpected errors structure received from CS execution.');
         }
@@ -320,7 +320,7 @@ abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase
      *
      * @param array $warnings warning results produced by the CS execution
      */
-    private function verifyWarnings($warnings) {
+    private function verifyWarnings($warnings): void {
         if (!is_array($warnings)) {
             $this->fail('Unexpected warnings structure received from CS execution.');
         }
@@ -335,7 +335,7 @@ abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase
      * @param array $results error|warning generated results.
      * @param string $type results being asserted (errors, warnings). Used for output only.
      */
-    private function assertResults($expectations, $results, $type) {
+    private function assertResults($expectations, $results, $type): void {
         foreach ($expectations as $line => $expectation) {
             // Build some information to be shown in case of problems.
             $info = '';

--- a/moodle/Tests/PHPUnitTestCaseNamesTest.php
+++ b/moodle/Tests/PHPUnitTestCaseNamesTest.php
@@ -29,6 +29,8 @@ class PHPUnitTestCaseNamesTest extends MoodleCSBaseTestCase
 {
     /**
      * Data provider for self::testPHPUnitTestCaseNamesProvider
+     *
+     * @return array
      */
     public function phpunitTestCaseNamesProvider() {
         return [

--- a/moodle/Tests/PHPUnitTestReturnTypeTest.php
+++ b/moodle/Tests/PHPUnitTestReturnTypeTest.php
@@ -29,6 +29,8 @@ class PHPUnitTestReturnTypeTest extends MoodleCSBaseTestCase
 {
     /**
      * Data provider for self::testPHPUnitTestReturnType
+     *
+     * @return array
      */
     public function providerPHPUnitTestReturnType(): array {
         return [

--- a/moodle/Tests/Sniffs/NamingConventions/ValidFunctionNameTest.php
+++ b/moodle/Tests/Sniffs/NamingConventions/ValidFunctionNameTest.php
@@ -31,6 +31,8 @@ class ValidFunctionNameTest extends MoodleCSBaseTestCase
 {
     /**
      * Data provider for self::testNamingConventionsValidFunctionName
+     *
+     * @return array
      */
     public function providerNamingConventionsValidFunctionName() {
         return [

--- a/moodle/Tests/Sniffs/PHPUnit/ParentSetUpTearDownSniffTest.php
+++ b/moodle/Tests/Sniffs/PHPUnit/ParentSetUpTearDownSniffTest.php
@@ -31,6 +31,8 @@ class ParentSetUpTearDownSniffTest extends MoodleCSBaseTestCase
 {
     /**
      * Data provider for self::testParentSetUpTearDown
+     *
+     * @return array
      */
     public static function parentSetUpTearDownProvider(): array {
         return [

--- a/moodle/Tests/Sniffs/PHPUnit/TestCaseCoversTest.php
+++ b/moodle/Tests/Sniffs/PHPUnit/TestCaseCoversTest.php
@@ -32,6 +32,8 @@ class TestCaseCoversTest extends MoodleCSBaseTestCase
 {
     /**
      * Data provider for self::testPHPUnitTestCaseCovers
+     *
+     * @return array
      */
     public function phpunitTestCaseCoversProvider() {
         return [

--- a/moodle/Tests/Sniffs/PHPUnit/TestCaseProviderTest.php
+++ b/moodle/Tests/Sniffs/PHPUnit/TestCaseProviderTest.php
@@ -32,6 +32,8 @@ class TestCaseProviderTest extends MoodleCSBaseTestCase
 {
     /**
      * Data provider for self::testPHPUnitTestCaseProvider
+     *
+     * @return array
      */
     public function phpunitTestCaseProviderProvider() {
         return [

--- a/moodle/Tests/Sniffs/PHPUnit/TestCasesAbstractSniffTest.php
+++ b/moodle/Tests/Sniffs/PHPUnit/TestCasesAbstractSniffTest.php
@@ -31,6 +31,8 @@ class TestCasesAbstractSniffTest extends MoodleCSBaseTestCase
 {
     /**
      * Data provider for self::testPHPUnitTestCasesAbstract
+     *
+     * @return array
      */
     public static function phpunitTestCasesAbstractProvider(): array {
         return [

--- a/moodle/Tests/Sniffs/PHPUnit/TestClassesFinalSniffTest.php
+++ b/moodle/Tests/Sniffs/PHPUnit/TestClassesFinalSniffTest.php
@@ -31,6 +31,8 @@ class TestclassesFinalSniffTest extends MoodleCSBaseTestCase
 {
     /**
      * Data provider for self::testPHPUnitClassesFinal
+     *
+     * @return array
      */
     public static function phpunitClassesFinalProvider(): array {
         return [

--- a/moodle/Tests/Util/MoodleUtilTest.php
+++ b/moodle/Tests/Util/MoodleUtilTest.php
@@ -106,6 +106,8 @@ class MoodleUtilTest extends MoodleCSBaseTestCase
 
     /**
      * Provider for test_getMoodleComponent.
+     *
+     * @return array
      */
     public function getMoodleComponentProvider() {
         return [
@@ -228,6 +230,8 @@ class MoodleUtilTest extends MoodleCSBaseTestCase
 
     /**
      * Provider for test_getMoodleBranch.
+     *
+     * @return array
      */
     public function getMoodleBranchProvider() {
         return [
@@ -329,6 +333,8 @@ class MoodleUtilTest extends MoodleCSBaseTestCase
 
     /**
      * Provider for test_getMoodleRoot.
+     *
+     * @return array
      */
     public function getMoodleRootProvider() {
         return [
@@ -386,9 +392,9 @@ class MoodleUtilTest extends MoodleCSBaseTestCase
      *
      * @param array $config get the Config from provider.
      * @param array $return expected result of the test.
+     * @param bool $requireMockMoodle Whether a mock Moodle root is required for this test.
      * @param bool $reset to decide if static caches should be reset before the test.
      * @param bool $selfPath to decide if moodle-cs own path is good to find a valid moodle root.
-     * @param bool $requireMockMoodle Whether a mock Moodle root is required for this test.
      *
      * @dataProvider getMoodleRootProvider
      */

--- a/moodle/Util/Docblocks.php
+++ b/moodle/Util/Docblocks.php
@@ -108,7 +108,7 @@ abstract class Docblocks
     /**
      * List of tags that should be renamed.
      *
-     * @var string[string]
+     * @var array<string, string>
      */
     private static array $renameTags = [
         // Rename returns to return.
@@ -119,7 +119,7 @@ abstract class Docblocks
      * A list of phpdoc tags allowed to be used under certain directories.
      * keys are tags, values are arrays of allowed paths (regexp patterns).
      *
-     * @var array(string => array(string))
+     * @var array<string, string[]>
      */
     private static array $pathRestrictedTags = [
         'Given' => ['#.*/tests/behat/.*#'],
@@ -295,6 +295,7 @@ abstract class Docblocks
      * @param File $phpcsFile
      * @param int|null $stackPtr The pointer of the docblock
      * @param string $tagName
+     * @return int[]
      */
     public static function getMatchingDocTags(
         File $phpcsFile,

--- a/moodle/Util/MoodleUtil.php
+++ b/moodle/Util/MoodleUtil.php
@@ -461,7 +461,7 @@ abstract class MoodleUtil
      * Get the path to the version.php file from the given path.
      *
      * @param string $path
-     * @return array|string|null
+     * @return string|null
      */
     private static function findVersionFileFromPath(string $path): ?string {
         $lastPath = $path;
@@ -600,7 +600,7 @@ abstract class MoodleUtil
      * If a version could not be determined, null is returned.
      *
      * @param File $phpcsFile The file to check
-     * @param int The minimum version to check against as a 2, or 3 digit number.
+     * @param int $version The minimum version to check against as a 2, or 3 digit number.
      * @return null|bool
      */
     public static function meetsMinimumMoodleVersion(
@@ -662,7 +662,7 @@ abstract class MoodleUtil
     /**
      * Get the standardised filename for the file.
      *
-     * @param File @phpcsFile
+     * @param File $phpcsFile
      * @return string
      */
     public static function getStandardisedFilename(File $phpcsFile): string {


### PR DESCRIPTION
I've run a basic PHPDoc type checker over the code, and tidied up a few things.  I think it's probably good for moodle-cs to set a good example.

Note:  I know the PHPCS Sniff function process() specifies its return type as void|int, but AFAIK, void is a stand-alone type, and int|null is the correct type.