### PR TITLE
Fix imported Override attribute handling

### DIFF
--- a/moodle/Sniffs/Commenting/MissingDocblockSniff.php
+++ b/moodle/Sniffs/Commenting/MissingDocblockSniff.php
@@ -189,15 +189,9 @@ class MissingDocblockSniff implements Sniff
 
         foreach ($missingDocblocks as $typePtr => $extendsOrImplements) {
             $token = $tokens[$typePtr];
-            if ($extendsOrImplements) {
-                $attributes = Attributes::getAttributePointers($phpcsFile, $typePtr);
-                foreach ($attributes as $attributePtr) {
-                    $attribute = Attributes::getAttributeProperties($phpcsFile, $attributePtr);
-                    if ($attribute['attribute_name'] === '\Override') {
-                        // Skip methods that are marked as overrides.
-                        continue 2;
-                    }
-                }
+            if ($extendsOrImplements && Attributes::hasAttribute($phpcsFile, $typePtr, 'Override')) {
+                // Skip methods that are marked as overrides.
+                continue;
             }
 
             $objectName = TokenUtil::getObjectName($phpcsFile, $typePtr);

--- a/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
+++ b/moodle/Tests/Sniffs/Commenting/MissingDocblockSniffTest.php
@@ -199,6 +199,18 @@ class MissingDocblockSniffTest extends MoodleCSBaseTestCase
                 'warnings' => [
                 ],
             ],
+            'With imported Override attribute' => [
+                'fixture' => 'with_imported_override',
+                'fixtureFilename' => null,
+                'errors' => [
+                    1 => 'Missing docblock for file with_imported_override.php',
+                    10 => 'Missing docblock for function has_override',
+                    12 => 'Missing docblock for function no_override',
+                    22 => 'Missing docblock for function no_override',
+                ],
+                'warnings' => [
+                ],
+            ],
             'Anonymous class as only class in file (documented)' => [
                 'fixture' => 'entire_anonymous_class_documented',
                 'fixtureFilename' => null,

--- a/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/with_imported_override.php
+++ b/moodle/Tests/Sniffs/Commenting/fixtures/MissingDocblock/with_imported_override.php
@@ -1,0 +1,23 @@
+<?php
+
+use Override;
+
+/**
+ * Base class docblock.
+ */
+class base_class {
+    #[Override]
+    public function has_override(): void {}
+
+    public function no_override(): void {}
+}
+
+/**
+ * Child class docblock.
+ */
+class child_class extends base_class {
+    #[Override]
+    public function has_override(): void {}
+
+    public function no_override(): void {}
+}

--- a/moodle/Tests/Sniffs/NamingConventions/fixtures/ValidFunctionName/validfunctionname_correct.php
+++ b/moodle/Tests/Sniffs/NamingConventions/fixtures/ValidFunctionName/validfunctionname_correct.php
@@ -1,6 +1,8 @@
 <?php
 defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
 
+use Override;
+
 class class_with_correct_function_names {
     public function __construct() {
         echo 'hi';
@@ -68,6 +70,13 @@ return new class {
 class example extends class_with_correct_function_names {
     #[\Override]
     public function childMethod(): void {
+        echo 'hi';
+    }
+}
+
+class imported_override_example extends class_with_correct_function_names {
+    #[Override]
+    public function childMethodImported(): void {
         echo 'hi';
     }
 }

--- a/moodle/Tests/Sniffs/PHPUnit/fixtures/Covers/testcasecovers_attribute_namespace_alias.php
+++ b/moodle/Tests/Sniffs/PHPUnit/fixtures/Covers/testcasecovers_attribute_namespace_alias.php
@@ -1,0 +1,14 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+namespace Example\Thing;
+
+use PHPUnit\Framework\Attributes as PHPUnitAttributes;
+
+#[PHPUnitAttributes\CoversClass(\some\namespace\one::class)]
+class correct_test extends base_test {
+    public function test_one() {
+        // Nothing to test.
+    }
+}
+

--- a/moodle/Tests/Sniffs/PHPUnit/fixtures/Covers/testcasecovers_method_covers_attribute.php
+++ b/moodle/Tests/Sniffs/PHPUnit/fixtures/Covers/testcasecovers_method_covers_attribute.php
@@ -1,0 +1,32 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+namespace Example\Thing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\CoversTrait;
+
+class correct_test extends base_test {
+    #[CoversClass(\some\namespace\one::class)]
+    public function test_one() {
+        // Nothing to test.
+    }
+
+    #[CoversTrait(\some\namespace\two::class)]
+    public function test_two() {
+        // Nothing to test.
+    }
+
+    #[CoversMethod(\some\namespace\three::class, 'someMethod')]
+    public function test_three() {
+        // Nothing to test.
+    }
+
+    #[CoversFunction('some_function')]
+    public function test_four() {
+        // Nothing to test.
+    }
+}
+

--- a/moodle/Tests/Util/AttributesTest.php
+++ b/moodle/Tests/Util/AttributesTest.php
@@ -331,6 +331,16 @@ class AttributesTest extends MoodleCSBaseTestCase
                 T_FUNCTION,
                 true,
             ],
+            'In a class, extends, has imported Override' => [
+                '<?php
+                use Override;
+                class Example extends OtherExample {
+                    #[Override]
+                    function exampleFunction(string $param): void {}
+                }',
+                T_FUNCTION,
+                true,
+            ],
             'In a class, implements, has Override' => [
                 '<?php
                 class Example implements OtherExample {

--- a/moodle/Util/Attributes.php
+++ b/moodle/Util/Attributes.php
@@ -68,7 +68,7 @@ abstract class Attributes
     /**
      * Get the properties of an Attribute.
      *
-     * Note: The attribute name is not currently qualified relative to the current namespace or any imported classes.
+     * Note: The attribute_name is the raw text from the source. Use qualified_name for import-aware comparisons.
      *
      * @param File $phpcsFile
      * @param int $stackPtr
@@ -238,14 +238,6 @@ abstract class Attributes
             return false;
         }
 
-        $attributes = self::getAttributePointers($phpcsFile, $stackPtr);
-        foreach ($attributes as $attributePtr) {
-            $attribute = self::getAttributeProperties($phpcsFile, $attributePtr);
-            if ($attribute['attribute_name'] === '\Override') {
-                return true;
-            }
-        }
-
-        return false;
+        return self::hasAttribute($phpcsFile, $stackPtr, 'Override');
     }
 }


### PR DESCRIPTION
Methods marked with `#[Override]` were still triggering some sniffs when the attribute was imported with use `Override;` because the checks were looking for exactly `\Override` and missed imported usages like `#[Override]`.

This patch updates the sniff to use the qualified attribute name instead of the raw token.