### PR TITLE
Add dependency injection coding standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 The format of this change log follows the advice given at [Keep a CHANGELOG](https://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- Add new `moodle.PHP.ForbiddenContainerInjection` sniff to prevent application code from receiving the dependency injection
+  container instead of declaring its actual service dependencies.
+- Add new opt-in `MoodleExtra.PHP.DiscouragedContainerLookup` sniff to warn when classes access the dependency injection
+  container instead of declaring dependencies.
+
 ### Removed
 - Support for PHPCompatibility until moodle-cs is upgraded to support PHP_CodeSniffer version 4.
 

--- a/moodle-extra/Sniffs/PHP/DiscouragedContainerLookupSniff.php
+++ b/moodle-extra/Sniffs/PHP/DiscouragedContainerLookupSniff.php
@@ -1,0 +1,223 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\MoodleExtra\Sniffs\PHP;
+
+use MoodleHQ\MoodleCS\moodle\Util\MoodleUtil;
+use MoodleHQ\MoodleCS\moodle\Util\NamespaceScopeUtil;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\GetTokensAsString;
+use PHPCSUtils\Utils\Namespaces;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Warns when a class accesses the dependency injection container directly.
+ *
+ * @copyright 2026 Cameron Ball <cameron@cameron1729.xyz>
+ * @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class DiscouragedContainerLookupSniff implements Sniff
+{
+    /**
+     * Whether to ignore files in test directories.
+     */
+    public bool $ignoreTestFiles = true;
+
+    /**
+     * Core classes which implement the container or its framework integration.
+     *
+     * @var string[]
+     */
+    public array $allowedClasses = [
+        'core\di',
+        'core\router\bridge',
+        'core\router\controller_invoker',
+        'core\router\response_handler',
+    ];
+
+    /**
+     * Register for possible static method names.
+     *
+     * @return array<int|string>
+     */
+    public function register() {
+        return [T_STRING];
+    }
+
+    /**
+     * Check for direct container lookups inside object scopes.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The string token being inspected.
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr) {
+        $tokens = $phpcsFile->getTokens();
+        $method = strtolower($tokens[$stackPtr]['content']);
+        if (!in_array($method, ['get', 'get_container'], true)) {
+            return;
+        }
+
+        if ($this->ignoreTestFiles && $this->isTestFile($phpcsFile)) {
+            return;
+        }
+
+        $objectPtr = $this->getEnclosingObjectScope($tokens[$stackPtr]['conditions']);
+        if ($objectPtr === null) {
+            return;
+        }
+
+        $doubleColon = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true);
+        if ($doubleColon === false || $tokens[$doubleColon]['code'] !== T_DOUBLE_COLON) {
+            return;
+        }
+
+        $openParenthesis = $phpcsFile->findNext(Tokens::$emptyTokens, $stackPtr + 1, null, true);
+        if ($openParenthesis === false || $tokens[$openParenthesis]['code'] !== T_OPEN_PARENTHESIS) {
+            return;
+        }
+
+        $className = $this->getStaticClassName($phpcsFile, $doubleColon);
+        if ($className === null) {
+            return;
+        }
+
+        $qualifiedClass = $this->getQualifiedClassName($phpcsFile, $stackPtr, $className);
+        if (strcasecmp($qualifiedClass, 'core\di') !== 0 || $this->isAllowedClass($phpcsFile, $objectPtr)) {
+            return;
+        }
+
+        $message = 'Calling %s::%s() inside a class is service location unless this method is a composition root; ' .
+            'inject the required service or suppress this warning at an intentional boundary.';
+        $phpcsFile->addWarning(
+            $message,
+            $stackPtr,
+            'InClass',
+            [$qualifiedClass, $method]
+        );
+    }
+
+    /**
+     * Whether this is a file in a test directory.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @return bool
+     */
+    private function isTestFile(File $phpcsFile): bool {
+        $filename = MoodleUtil::getStandardisedFilename($phpcsFile);
+        return stripos($filename, '/tests/') !== false;
+    }
+
+    /**
+     * Get the innermost enclosing object scope.
+     *
+     * @param array<int, int|string> $conditions The token's enclosing conditions.
+     * @return int|null The object declaration token, or null when outside an object scope.
+     */
+    private function getEnclosingObjectScope(array $conditions): ?int {
+        foreach (array_reverse($conditions, true) as $conditionPtr => $conditionCode) {
+            if (isset(Tokens::$ooScopeTokens[$conditionCode])) {
+                return $conditionPtr;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find the class name to the left of a static access operator.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $doubleColon The static access operator token.
+     * @return string|null
+     */
+    private function getStaticClassName(File $phpcsFile, int $doubleColon): ?string {
+        $tokens = $phpcsFile->getTokens();
+        $classEnd = $phpcsFile->findPrevious(Tokens::$emptyTokens, $doubleColon - 1, null, true);
+        if ($classEnd === false || !isset(Collections::namespacedNameTokens()[$tokens[$classEnd]['code']])) {
+            return null;
+        }
+
+        $classStart = $classEnd;
+        while ($classStart > 0) {
+            $previous = $phpcsFile->findPrevious(Tokens::$emptyTokens, $classStart - 1, null, true);
+            if ($previous === false || !isset(Collections::namespacedNameTokens()[$tokens[$previous]['code']])) {
+                break;
+            }
+            $classStart = $previous;
+        }
+
+        return GetTokensAsString::noEmpties($phpcsFile, $classStart, $classEnd);
+    }
+
+    /**
+     * Qualify a class name relative to its namespace and imported aliases.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The static method name token.
+     * @param string $className The declared class name.
+     * @return string
+     */
+    private function getQualifiedClassName(File $phpcsFile, int $stackPtr, string $className): string {
+        if (substr($className, 0, 1) === '\\') {
+            return substr($className, 1);
+        }
+
+        if (strncasecmp($className, 'namespace\\', 10) === 0) {
+            $namespace = Namespaces::determineNamespace($phpcsFile, $stackPtr);
+            $relativeClass = substr($className, 10);
+            return $namespace === '' ? $relativeClass : "{$namespace}\\{$relativeClass}";
+        }
+
+        $separator = strpos($className, '\\');
+        $alias = $separator === false ? $className : substr($className, 0, $separator);
+        $remainder = $separator === false ? '' : substr($className, $separator);
+        foreach (NamespaceScopeUtil::getClassImports($phpcsFile, $stackPtr) as $importAlias => $import) {
+            if (strcasecmp($importAlias, $alias) === 0) {
+                return ltrim($import, '\\') . $remainder;
+            }
+        }
+
+        return NamespaceScopeUtil::getQualifiedName($phpcsFile, $stackPtr, $className);
+    }
+
+    /**
+     * Whether the call belongs to approved container infrastructure.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $objectPtr The object declaration token.
+     * @return bool
+     */
+    private function isAllowedClass(File $phpcsFile, int $objectPtr): bool {
+        $className = ObjectDeclarations::getName($phpcsFile, $objectPtr);
+        if ($className === null) {
+            return false;
+        }
+
+        $qualifiedClass = NamespaceScopeUtil::getQualifiedName($phpcsFile, $objectPtr, $className);
+        foreach ($this->allowedClasses as $allowedClass) {
+            if (strcasecmp(ltrim($allowedClass, '\\'), $qualifiedClass) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/moodle-extra/ruleset.xml
+++ b/moodle-extra/ruleset.xml
@@ -19,6 +19,11 @@
 
     <!-- Draft rulesets -->
 
+    <!-- Warn when classes use the DI container as a service locator. -->
+    <rule ref="moodle-extra.PHP.DiscouragedContainerLookup">
+        <type>warning</type>
+    </rule>
+
     <!--
         Detect issues with Unit Test dataProviders:
         - private providers

--- a/moodle/Sniffs/PHP/ForbiddenContainerInjectionSniff.php
+++ b/moodle/Sniffs/PHP/ForbiddenContainerInjectionSniff.php
@@ -1,0 +1,164 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHP;
+
+use MoodleHQ\MoodleCS\moodle\Util\NamespaceScopeUtil;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\FunctionDeclarations;
+use PHPCSUtils\Utils\Namespaces;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+/**
+ * Prevents application code from receiving the dependency injection container.
+ *
+ * @copyright 2026 Cameron Ball <cameron@cameron1729.xyz>
+ * @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class ForbiddenContainerInjectionSniff implements Sniff
+{
+    /**
+     * Container types which application code must not receive.
+     */
+    private const FORBIDDEN_TYPES = [
+        'core\di' => true,
+        'di\container' => true,
+        'psr\container\containerinterface' => true,
+    ];
+
+    /**
+     * Core classes which implement the container or its framework integration.
+     *
+     * @var string[]
+     */
+    public array $allowedClasses = [
+        'core\di',
+        'core\router\bridge',
+        'core\router\controller_invoker',
+        'core\router\response_handler',
+    ];
+
+    /**
+     * Register for all function-like declarations.
+     *
+     * @return array<int|string>
+     */
+    public function register() {
+        return Collections::functionDeclarationTokens();
+    }
+
+    /**
+     * Check declared parameter types for injected containers.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The function declaration token.
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr) {
+        if ($this->isAllowedClass($phpcsFile, $stackPtr)) {
+            return;
+        }
+
+        foreach (FunctionDeclarations::getParameters($phpcsFile, $stackPtr) as $parameter) {
+            if ($parameter['type_hint'] === '') {
+                continue;
+            }
+
+            $types = preg_split('/[?&|()\s]+/', $parameter['type_hint'], -1, PREG_SPLIT_NO_EMPTY);
+            foreach ($types as $type) {
+                $qualifiedType = $this->getQualifiedTypeName($phpcsFile, $parameter['type_hint_token'], $type);
+                if (!isset(self::FORBIDDEN_TYPES[strtolower($qualifiedType)])) {
+                    continue;
+                }
+
+                $phpcsFile->addError(
+                    'The container type %s must not be injected; declare the required service as a dependency instead.',
+                    $parameter['type_hint_token'],
+                    'ContainerInjected',
+                    [$qualifiedType]
+                );
+                break;
+            }
+        }
+    }
+
+    /**
+     * Whether the function belongs to approved container infrastructure.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The function declaration token.
+     * @return bool
+     */
+    private function isAllowedClass(File $phpcsFile, int $stackPtr): bool {
+        $tokens = $phpcsFile->getTokens();
+        foreach (array_reverse($tokens[$stackPtr]['conditions'], true) as $conditionPtr => $conditionCode) {
+            if (!isset(Tokens::$ooScopeTokens[$conditionCode])) {
+                continue;
+            }
+
+            $className = ObjectDeclarations::getName($phpcsFile, $conditionPtr);
+            if ($className === null) {
+                return false;
+            }
+
+            $qualifiedClass = NamespaceScopeUtil::getQualifiedName($phpcsFile, $conditionPtr, $className);
+            foreach ($this->allowedClasses as $allowedClass) {
+                if (strcasecmp(ltrim($allowedClass, '\\'), $qualifiedClass) === 0) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    /**
+     * Qualify a type relative to its namespace and imported class aliases.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The type declaration token.
+     * @param string $type The declared type.
+     * @return string
+     */
+    private function getQualifiedTypeName(File $phpcsFile, int $stackPtr, string $type): string {
+        if (substr($type, 0, 1) === '\\') {
+            return substr($type, 1);
+        }
+
+        if (strncasecmp($type, 'namespace\\', 10) === 0) {
+            $namespace = Namespaces::determineNamespace($phpcsFile, $stackPtr);
+            $relativeType = substr($type, 10);
+            return $namespace === '' ? $relativeType : "{$namespace}\\{$relativeType}";
+        }
+
+        $separator = strpos($type, '\\');
+        $alias = $separator === false ? $type : substr($type, 0, $separator);
+        $remainder = $separator === false ? '' : substr($type, $separator);
+        foreach (NamespaceScopeUtil::getClassImports($phpcsFile, $stackPtr) as $importAlias => $import) {
+            if (strcasecmp($importAlias, $alias) === 0) {
+                return ltrim($import, '\\') . $remainder;
+            }
+        }
+
+        return NamespaceScopeUtil::getQualifiedName($phpcsFile, $stackPtr, $type);
+    }
+}

--- a/moodle/Tests/MoodleCSBaseTestCase.php
+++ b/moodle/Tests/MoodleCSBaseTestCase.php
@@ -213,6 +213,14 @@ abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase
         $config->ignored   = [];
         $ruleset = new \PHP_CodeSniffer\Ruleset($config);
 
+        // PHPCS test mode assumes that the standard directory and the first part of the sniff code match.
+        // Fall back to loading the standard before selecting the sniff when a standard uses a different namespace.
+        if (empty($ruleset->sniffCodes)) {
+            $config->sniffs = [];
+            $ruleset = new \PHP_CodeSniffer\Ruleset($config);
+            $this->restrictRulesetToSniff($ruleset, $this->sniff);
+        }
+
         // We don't accept undefined errors and warnings.
         if (is_null($this->errors) && is_null($this->warnings)) {
             $this->fail('Error and warning expectations undefined. You must define at least one.');
@@ -274,6 +282,43 @@ abstract class MoodleCSBaseTestCase extends \PHPUnit\Framework\TestCase
         if (empty($fixerrors) === false) {
             $this->fail(implode(PHP_EOL, $fixerrors));
         }
+    }
+
+    /**
+     * Restrict a loaded ruleset to a single sniff.
+     *
+     * @param \PHP_CodeSniffer\Ruleset $ruleset The ruleset to restrict.
+     * @param string $sniffCode The sniff code to retain.
+     * @return void
+     */
+    private function restrictRulesetToSniff(\PHP_CodeSniffer\Ruleset $ruleset, string $sniffCode): void {
+        $matchedCode = null;
+        $matchedClass = null;
+        foreach ($ruleset->sniffCodes as $code => $class) {
+            if (strcasecmp($code, $sniffCode) === 0) {
+                $matchedCode = $code;
+                $matchedClass = $class;
+                break;
+            }
+        }
+
+        if ($matchedClass === null) {
+            throw new \InvalidArgumentException("Sniff {$sniffCode} is not part of standard {$this->standard}.");
+        }
+
+        foreach ($ruleset->tokenListeners as $token => $listeners) {
+            foreach (array_keys($listeners) as $class) {
+                if ($class !== $matchedClass) {
+                    unset($ruleset->tokenListeners[$token][$class]);
+                }
+            }
+            if (empty($ruleset->tokenListeners[$token])) {
+                unset($ruleset->tokenListeners[$token]);
+            }
+        }
+
+        $ruleset->sniffs = [$matchedClass => $ruleset->sniffs[$matchedClass]];
+        $ruleset->sniffCodes = [$matchedCode => $matchedClass];
     }
 
     /**

--- a/moodle/Tests/Sniffs/PHP/DiscouragedContainerLookupSniffTest.php
+++ b/moodle/Tests/Sniffs/PHP/DiscouragedContainerLookupSniffTest.php
@@ -1,0 +1,90 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHP;
+
+use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
+
+/**
+ * Tests for discouraged container lookups inside classes.
+ *
+ * @copyright 2026 Cameron Ball <cameron@cameron1729.xyz>
+ * @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \MoodleHQ\MoodleCS\MoodleExtra\Sniffs\PHP\DiscouragedContainerLookupSniff
+ */
+class DiscouragedContainerLookupSniffTest extends MoodleCSBaseTestCase
+{
+    /**
+     * Test lookups using different namespace and alias forms.
+     */
+    public function testDiscouragedContainerLookups(): void {
+        $this->setStandard('moodle-extra');
+        $this->setSniff('MoodleExtra.PHP.DiscouragedContainerLookup');
+        $this->setFixture(
+            __DIR__ . '/fixtures/DiscouragedContainerLookup/general.php',
+            '/var/www/local/example/classes/service.php'
+        );
+
+        $this->setErrors([]);
+        $this->setWarnings([
+            40 => 'Calling core\di::get() inside a class is service location',
+            41 => 'Calling core\di::get() inside a class is service location',
+            42 => 'Calling core\di::get() inside a class is service location',
+            43 => 'Calling core\di::get_container() inside a class is service location',
+            49 => 'Calling core\di::get() inside a class is service location',
+            55 => 'Calling core\di::get() inside a class is service location',
+            68 => 'Calling core\di::get() inside a class is service location',
+            76 => 'Calling core\di::get() inside a class is service location',
+            77 => 'Calling core\di::get_container() inside a class is service location',
+        ]);
+
+        $this->verifyCsResults();
+    }
+
+    /**
+     * Test known container infrastructure.
+     */
+    public function testAllowedContainerLookups(): void {
+        $this->setStandard('moodle-extra');
+        $this->setSniff('MoodleExtra.PHP.DiscouragedContainerLookup');
+        $this->setFixture(
+            __DIR__ . '/fixtures/DiscouragedContainerLookup/allowed.php',
+            '/var/www/lib/classes/router/bridge.php'
+        );
+        $this->setErrors([]);
+        $this->setWarnings([]);
+
+        $this->verifyCsResults();
+    }
+
+    /**
+     * Test that test paths are ignored by default.
+     */
+    public function testTestFilesIgnored(): void {
+        $this->setStandard('moodle-extra');
+        $this->setSniff('MoodleExtra.PHP.DiscouragedContainerLookup');
+        $this->setFixture(
+            __DIR__ . '/fixtures/DiscouragedContainerLookup/test_file.php',
+            '/var/www/local/example/tests/service_test.php'
+        );
+        $this->setErrors([]);
+        $this->setWarnings([]);
+
+        $this->verifyCsResults();
+    }
+}

--- a/moodle/Tests/Sniffs/PHP/ForbiddenContainerInjectionSniffTest.php
+++ b/moodle/Tests/Sniffs/PHP/ForbiddenContainerInjectionSniffTest.php
@@ -1,0 +1,73 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Tests\Sniffs\PHP;
+
+use MoodleHQ\MoodleCS\moodle\Tests\MoodleCSBaseTestCase;
+
+/**
+ * Tests for the forbidden container injection sniff.
+ *
+ * @copyright 2026 Cameron Ball <cameron@cameron1729.xyz>
+ * @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHP\ForbiddenContainerInjectionSniff
+ */
+class ForbiddenContainerInjectionSniffTest extends MoodleCSBaseTestCase
+{
+    /**
+     * Test forbidden types in different namespace and parameter type forms.
+     */
+    public function testForbiddenContainerInjection(): void {
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHP.ForbiddenContainerInjection');
+        $this->setFixture(__DIR__ . '/fixtures/ForbiddenContainerInjection/general.php');
+
+        $this->setErrors([
+            32 => 'The container type Psr\Container\ContainerInterface must not be injected',
+            37 => 'The container type Psr\Container\ContainerInterface must not be injected',
+            42 => 'The container type Psr\Container\ContainerInterface must not be injected',
+            47 => 'The container type Psr\Container\ContainerInterface must not be injected',
+            52 => 'The container type Psr\Container\ContainerInterface must not be injected',
+            57 => 'The container type core\di must not be injected',
+            62 => 'The container type DI\Container must not be injected',
+            66 => 'The container type Psr\Container\ContainerInterface must not be injected',
+            69 => 'The container type Psr\Container\ContainerInterface must not be injected',
+            72 => 'The container type DI\Container must not be injected',
+            77 => 'The container type Psr\Container\ContainerInterface must not be injected',
+            84 => 'The container type core\di must not be injected',
+            98 => 'The container type Psr\Container\ContainerInterface must not be injected',
+            105 => 'The container type Psr\Container\ContainerInterface must not be injected',
+        ]);
+        $this->setWarnings([]);
+
+        $this->verifyCsResults();
+    }
+
+    /**
+     * Test the narrow allowlist for Moodle's container integration itself.
+     */
+    public function testContainerInfrastructureAllowlist(): void {
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHP.ForbiddenContainerInjection');
+        $this->setFixture(__DIR__ . '/fixtures/ForbiddenContainerInjection/allowed.php');
+        $this->setErrors([]);
+        $this->setWarnings([]);
+
+        $this->verifyCsResults();
+    }
+}

--- a/moodle/Tests/Sniffs/PHP/fixtures/DiscouragedContainerLookup/allowed.php
+++ b/moodle/Tests/Sniffs/PHP/fixtures/DiscouragedContainerLookup/allowed.php
@@ -1,0 +1,26 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace core\router;
+
+use core\di;
+
+class bridge {
+    public static function create(): void {
+        di::get_container();
+    }
+}

--- a/moodle/Tests/Sniffs/PHP/fixtures/DiscouragedContainerLookup/general.php
+++ b/moodle/Tests/Sniffs/PHP/fixtures/DiscouragedContainerLookup/general.php
@@ -1,0 +1,89 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_example;
+
+use core\di;
+use core\di as moodle_di;
+use core as moodle_core;
+
+function global_composition_root(): void {
+    \core\di::get(service::class);
+}
+
+class valid_service {
+    public function get(): void {
+    }
+
+    public function run(): void {
+        unrelated\di::get(service::class);
+        di::other_method();
+    }
+}
+
+class service_locator {
+    public function run(): void {
+        \core\di::get(service::class);
+        di::get(service::class);
+        moodle_di::GET(service::class);
+        moodle_core\di::get_container();
+    }
+}
+
+trait service_locator_trait {
+    public function run(): void {
+        \core\di::get(service::class);
+    }
+}
+
+class nested_lookup {
+    public function run(): void {
+        $callback = fn() => \core\di::get(service::class);
+    }
+}
+
+class intentional_boundary {
+    public function run(): void {
+        // phpcs:ignore MoodleExtra.PHP.DiscouragedContainerLookup.InClass -- Intentional composition root.
+        \core\di::get(service::class);
+    }
+}
+
+$anonymous = new class {
+    public function run(): void {
+        \core\di::get(service::class);
+    }
+};
+
+namespace core;
+
+class relative_lookup {
+    public function run(): void {
+        di::get(\stdClass::class);
+        namespace\di::get_container();
+    }
+}
+
+namespace local_example;
+
+class static_syntax {
+    public function run(): void {
+        \core\di::get;
+        $class = \core\di::class;
+        $class::get(service::class);
+    }
+}

--- a/moodle/Tests/Sniffs/PHP/fixtures/DiscouragedContainerLookup/test_file.php
+++ b/moodle/Tests/Sniffs/PHP/fixtures/DiscouragedContainerLookup/test_file.php
@@ -1,0 +1,25 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_example;
+
+class service_test {
+    public function test_service(): void {
+        \core\di::get(service::class);
+        \core\di::get_container();
+    }
+}

--- a/moodle/Tests/Sniffs/PHP/fixtures/ForbiddenContainerInjection/allowed.php
+++ b/moodle/Tests/Sniffs/PHP/fixtures/ForbiddenContainerInjection/allowed.php
@@ -1,0 +1,44 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace core\router;
+
+use Psr\Container\ContainerInterface;
+
+class bridge {
+    public static function create(?ContainerInterface $container = null): void {
+    }
+}
+
+class controller_invoker {
+    public function __construct(ContainerInterface $container) {
+    }
+}
+
+class response_handler {
+    public function __construct(ContainerInterface $container) {
+    }
+}
+
+namespace core;
+
+use Psr\Container\ContainerInterface;
+
+class di {
+    public static function replace(ContainerInterface $container): void {
+    }
+}

--- a/moodle/Tests/Sniffs/PHP/fixtures/ForbiddenContainerInjection/general.php
+++ b/moodle/Tests/Sniffs/PHP/fixtures/ForbiddenContainerInjection/general.php
@@ -1,0 +1,107 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_example;
+
+use core\di;
+use DI\Container as PhpDiContainer;
+use Psr\Container as PsrContainer;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerInterface as ContainerAlias;
+
+class valid_consumer {
+    public function __construct(\core\clock $clock) {
+    }
+}
+
+class fully_qualified_consumer {
+    public function __construct(\Psr\Container\ContainerInterface $container) {
+    }
+}
+
+class imported_consumer {
+    public function __construct(ContainerInterface $container) {
+    }
+}
+
+class aliased_consumer {
+    public function set_container(ContainerAlias $container): void {
+    }
+}
+
+class namespace_alias_consumer {
+    public function set_container(PsrContainer\ContainerInterface $container): void {
+    }
+}
+
+class complex_type_consumer {
+    public function set_container((ContainerInterface&\Stringable)|null $container): void {
+    }
+}
+
+class core_di_consumer {
+    public function __construct(di $container) {
+    }
+}
+
+class php_di_consumer {
+    public function __construct(PhpDiContainer $container) {
+    }
+}
+
+function create_from_container(?ContainerAlias $container): void {
+}
+
+$closure = function (ContainerInterface $container): void {
+};
+
+$arrow = fn(PhpDiContainer $container): PhpDiContainer => $container;
+
+namespace Psr\Container;
+
+class relative_interface_consumer {
+    public function __construct(ContainerInterface $container) {
+    }
+}
+
+namespace core;
+
+class relative_di_consumer {
+    public function __construct(di $container) {
+    }
+}
+
+namespace local_example_fallback;
+
+class parser_edge_consumer {
+    public function run($untyped): void {
+        $callback = function (local_dependency $dependency): void {
+        };
+    }
+}
+
+$anonymous = new class {
+    public function __construct(\Psr\Container\ContainerInterface $container) {
+    }
+};
+
+namespace Psr\Container;
+
+class namespace_relative_type_consumer {
+    public function __construct(namespace\ContainerInterface $container) {
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
   <coverage cacheDirectory=".phpunit.cache/code-coverage" processUncoveredFiles="true">
     <include>
         <directory suffix=".php">moodle/Sniffs</directory>
+        <directory suffix=".php">moodle-extra/Sniffs</directory>
         <directory suffix=".php">moodle/Util</directory>
     </include>
     <report>


### PR DESCRIPTION
## Summary
This PR adds guidance for using Moodle's dependency injection container without introducing service location patterns.

It introduces two checks:

  - A coding standard error when application code receives the DI container as a dependency (this is explicitly prohibited in developer documentation)
  - An opt-in warning in moodle-extra, for when a class performs direct `\core\di` lookups

## Rationale
Dependency injection means that classes declare their immediate collaborators. Injecting the container instead gives a class access to arbitrary services, hides its real dependencies, and effectively turns the container into a service locator.

Direct container lookups inside classes are also usually service location. However, container access is legitimate at composition roots and other application boundaries, so this is provided as a warning through Moodle Extra rather than an unconditional error.

## Related work
This change was prompted by the propsed Calendar API migration in [MDL-89216](https://moodle.atlassian.net/browse/MDL-89216), but the coding standard rules added here apply generally to the existing DI container and can be merged independently.

Supporting improvements to the developer documentation are also in progress here: https://github.com/moodle/devdocs/pull/1640

[MDL-89216]: https://moodle.atlassian.net/browse/MDL-89216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ