### PR TITLE
Add sniff detecting deprecated $CFG properties.

### DIFF
--- a/moodle/Sniffs/PHP/DeprecatedCFGPropertiesSniff.php
+++ b/moodle/Sniffs/PHP/DeprecatedCFGPropertiesSniff.php
@@ -1,0 +1,140 @@
+<?php
+
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace MoodleHQ\MoodleCS\moodle\Sniffs\PHP;
+
+use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Detects usage of deprecated $CFG properties.
+ *
+ * Some $CFG properties (for example, $CFG->httpswwwroot) have been removed from
+ * Moodle core but are kept as aliases for backwards compatibility with contributed
+ * plugins. This sniff warns whenever such a property is accessed, so that plugin
+ * developers can migrate away from them before they are removed for good.
+ *
+ * See MDLSITE-6012 and related MDL-67250 / MDL-89722.
+ *
+ * @copyright  2026 onwards Paul Holden <paulh.moodle@gmail.com>
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class DeprecatedCFGPropertiesSniff extends AbstractVariableSniff
+{
+    /**
+     * List of deprecated $CFG properties.
+     *
+     * Keys are the deprecated property names, values are their suggested
+     * replacements (or null when there is no direct replacement).
+     *
+     * @var array<string, string|null>
+     */
+    public $deprecatedProperties = [
+        'httpswwwroot' => 'wwwroot',
+    ];
+
+    /**
+     * Processes class member variables.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The position of the current token in the stack.
+     */
+    protected function processMemberVar(File $phpcsFile, $stackPtr) {
+        // Not applicable: class member variables cannot be $CFG.
+    }
+
+    /**
+     * Processes normal variables.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The position of the current token in the stack.
+     */
+    protected function processVariable(File $phpcsFile, $stackPtr) {
+        $tokens = $phpcsFile->getTokens();
+
+        if (ltrim($tokens[$stackPtr]['content'], '$') !== 'CFG') {
+            return;
+        }
+
+        // Look for '->' immediately after (skipping whitespace).
+        $next = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
+        if ($next === false || $tokens[$next]['code'] !== T_OBJECT_OPERATOR) {
+            return;
+        }
+
+        // Look for the property name after '->'.
+        $propertyPtr = $phpcsFile->findNext(T_WHITESPACE, $next + 1, null, true);
+        if ($propertyPtr === false || $tokens[$propertyPtr]['code'] !== T_STRING) {
+            return;
+        }
+
+        $this->reportIfDeprecated($tokens[$propertyPtr]['content'], $phpcsFile, $propertyPtr);
+    }
+
+    /**
+     * Processes variables in double quoted strings.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The position of the current token in the stack.
+     */
+    protected function processVariableInString(File $phpcsFile, $stackPtr) {
+        $tokens = $phpcsFile->getTokens();
+
+        // Match $CFG->property inside double-quoted strings (and heredocs).
+        if (
+            preg_match_all(
+                '/(?<!\\\\)\$CFG->([A-Za-z_][A-Za-z0-9_]*)/',
+                $tokens[$stackPtr]['content'],
+                $matches
+            )
+        ) {
+            foreach ($matches[1] as $property) {
+                $this->reportIfDeprecated($property, $phpcsFile, $stackPtr);
+            }
+        }
+    }
+
+    /**
+     * Emit a warning if the given property is on the deprecated list.
+     *
+     * @param string $property The property name found on $CFG.
+     * @param File $phpcsFile The file being scanned.
+     * @param int $stackPtr The position to attach the warning to.
+     */
+    protected function reportIfDeprecated($property, File $phpcsFile, $stackPtr) {
+        if (!array_key_exists($property, $this->deprecatedProperties)) {
+            return;
+        }
+
+        $replacement = $this->deprecatedProperties[$property];
+        if ($replacement !== null && $replacement !== '') {
+            $phpcsFile->addWarning(
+                '$CFG->%s is deprecated; use $CFG->%s instead',
+                $stackPtr,
+                'DeprecatedCFGPropertyWithReplacement',
+                [$property, $replacement]
+            );
+        } else {
+            $phpcsFile->addWarning(
+                '$CFG->%s is deprecated and should not be used',
+                $stackPtr,
+                'DeprecatedCFGProperty',
+                [$property]
+            );
+        }
+    }
+}

--- a/moodle/Tests/MoodleStandardTest.php
+++ b/moodle/Tests/MoodleStandardTest.php
@@ -626,6 +626,34 @@ class MoodleStandardTest extends MoodleCSBaseTestCase
     }
 
     /**
+     * Test the moodle.PHP.DeprecatedCFGProperties sniff.
+     *
+     * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHP\DeprecatedCFGPropertiesSniff
+     */
+    public function testMoodlePHPDeprecatedCFGProperties() {
+        // Define the standard, sniff and fixture to use.
+        $this->setStandard('moodle');
+        $this->setSniff('moodle.PHP.DeprecatedCFGProperties');
+        $this->setFixture(__DIR__ . '/fixtures/moodle_php_deprecated_cfg_properties.php');
+
+        // Define expected results (errors and warnings). Format, array of:
+        // - line => number of problems,  or
+        // - line => array of contents for message / source problem matching.
+        // - line => string of contents for message / source problem matching (only 1).
+        $this->setErrors([]);
+        $this->setWarnings([
+            13 => '$CFG->httpswwwroot is deprecated; use $CFG->wwwroot instead',
+            14 => '$CFG->httpswwwroot is deprecated; use $CFG->wwwroot instead',
+            15 => '$CFG->httpswwwroot is deprecated; use $CFG->wwwroot instead',
+            16 => 0,
+            27 => 0,
+        ]);
+
+        // Let's do all the hard work!
+        $this->verifyCsResults();
+    }
+
+    /**
      * Test the moodle.PHP.ForbiddenTokens sniff.
      *
      * @covers \MoodleHQ\MoodleCS\moodle\Sniffs\PHP\ForbiddenTokensSniff

--- a/moodle/Tests/fixtures/moodle_php_deprecated_cfg_properties.php
+++ b/moodle/Tests/fixtures/moodle_php_deprecated_cfg_properties.php
@@ -1,0 +1,27 @@
+<?php
+defined('MOODLE_INTERNAL') || die(); // Make this always the 1st line in all CS fixtures.
+
+function ok_usages() {
+    global $CFG;
+    $a = $CFG->wwwroot;
+    $b = $CFG->dirroot;
+    return $a . $b;
+}
+
+function bad_usages() {
+    global $CFG;
+    $a = $CFG->httpswwwroot;
+    $b = $CFG -> httpswwwroot;
+    $c = "The site is at $CFG->httpswwwroot right now.";
+    $d = "Escaped \$CFG->httpswwwroot should not match.";
+    return [$a, $b, $c, $d];
+}
+
+class other_cfg {
+    public $httpswwwroot = 'not-global';
+}
+
+function unrelated_object() {
+    $cfg = new other_cfg();
+    return $cfg->httpswwwroot;
+}


### PR DESCRIPTION
Adds a new moodle.PHP.DeprecatedCFGProperties sniff that warns on any use of removed-but-aliased $CFG properties. Ships with an entry for $CFG->httpswwwroot (removed in Moodle 3.4, still aliased for BC), suggesting $CFG->wwwroot as the replacement.

Detects both bare-code accesses and references inside double-quoted strings / heredocs, and only fires when the variable is exactly $CFG.